### PR TITLE
Produce Nodes in the Fasten URI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 pycg==0.0.5
-pycg-stitch==0.0.8
+pycg-stitch==0.0.9
 requests==2.27.1
 urllib3==1.26.9
 Werkzeug==2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,3 @@
-certifi==2022.5.18.1
-charset-normalizer==2.0.12
-click==8.1.3
-Flask==2.1.2
-idna==3.3
-importlib-metadata==4.11.4
-itsdangerous==2.1.2
-Jinja2==3.1.2
-MarkupSafe==2.1.1
 pycg==0.0.5
 pycg-stitch==0.0.9
 requests==2.27.1
-urllib3==1.26.9
-Werkzeug==2.1.2
-zipp==3.8.0

--- a/src/fasten/stitchCallGraphs.py
+++ b/src/fasten/stitchCallGraphs.py
@@ -10,9 +10,9 @@ class StitchCallGraphs:
 
         print("Stitch Call Graphs")
 
-        stitcher = Stitcher(call_graphs, "simple")
+        stitcher = Stitcher(call_graphs, False)
         stitcher.stitch()
-        output = json.dumps(stitcher.output())
+        output = json.dumps(stitcher.output(), indent=2)
         stitched_call_graph = args.scg_path + args.product + ".json"
 
         with open(args.scg_path + args.product + ".json", "w+") as f:


### PR DESCRIPTION
# Description

This PR aims to fix the format of the produced stitched nodes. More precisely:
* Changed the format of the nodes produced from the Sticher in order to be compatible with the Fasten URIs.
* Updated the pycg-stich version to 0.0.9, which supports the correct Fasten URI format
*  Included in the dependency declaration of the project only the direct dependencies, since pip automatically resolves   the transitive dependencies using its resolution algorithm.
* Beautified the printed json output using indents

Fixes #17