### PR TITLE
Pypi plugin licensing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pycg==0.0.5
 pycg-stitch==0.0.9
 requests==2.27.1
 pkginfo==1.8.2
+pycg-producer==0.0.5

--- a/src/fasten/__main__.py
+++ b/src/fasten/__main__.py
@@ -1,18 +1,20 @@
 import argparse
 import time
-from fasten.executePypiResolver import ExecutePypiResolver
-from fasten.readRequirementsFile import ReadRequirementsFile
-from fasten.checkPackageAvailability import CheckPackageAvailability
-from fasten.createCallGraph import CreateCallGraph
-from fasten.requestFasten import RequestFasten
-from fasten.stitchCallGraphs import StitchCallGraphs
-from fasten.findEntrypoints import FindEntrypoints
-from fasten.createAdjacencyList import CreateAdjacencyList
-from fasten.depthFirstSearch import DepthFirstSearch
-from fasten.optimizeStitchedCallGraph import OptimizeStitchedCallGraph
-from fasten.enrichCallGraph import EnrichCallGraph
-from fasten.stitchedCallGraphAnalyzer import StitchedCallGraphAnalyzer
-from fasten.createDirectories import CreateDirectories
+from executePypiResolver import ExecutePypiResolver
+from readRequirementsFile import ReadRequirementsFile
+from checkPackageAvailability import CheckPackageAvailability
+from createCallGraph import CreateCallGraph
+from requestFasten import RequestFasten
+from stitchCallGraphs import StitchCallGraphs
+from findEntrypoints import FindEntrypoints
+from createAdjacencyList import CreateAdjacencyList
+from depthFirstSearch import DepthFirstSearch
+from optimizeStitchedCallGraph import OptimizeStitchedCallGraph
+from enrichCallGraph import EnrichCallGraph
+from stitchedCallGraphAnalyzer import StitchedCallGraphAnalyzer
+from createDirectories import CreateDirectories
+from collectingGeneratedAndRetrievedCallGraphs import collectingGeneratedAndRetrievedCallGraphs
+
 
 
 def main():
@@ -44,9 +46,14 @@ def main():
     pkgs = ReadRequirementsFile.readFile(args.requirements) # Read requirements.txt
     pkgs, unknown_pkgs = CheckPackageAvailability.checkPackageAvailability(pkgs, url) # Check if packages are known by FASTEN
 
+    ################################ CALL GRAPHS - Michele - Retrieve and Generation in one function ##################
+    call_graphs = collectingGeneratedAndRetrievedCallGraphs(args, all_pkgs, url)
+    print("call_graphs")
+    print(call_graphs)
 
-    call_graphs, cg_pkgs = RequestFasten.requestFasten(args, pkgs, url, "rcg")
-    call_graphs = CreateCallGraph().createCallGraph(args, forge, max_iter, operation, call_graphs)
+
+    #call_graphs, cg_pkgs = RequestFasten.requestFasten(args, pkgs, url, "rcg")
+    #call_graphs = CreateCallGraph().createCallGraph(args, forge, max_iter, operation, call_graphs)
     vulnerabilities, vul_pkgs = RequestFasten.requestFasten(args, pkgs, url, "vulnerabilities")
 
 #    pathsToCallGraphs = parser.parse_args(call_graphs)

--- a/src/fasten/__main__.py
+++ b/src/fasten/__main__.py
@@ -91,7 +91,7 @@ def main():
         print("Vulnerabilities can be found in " + args.fasten_data + package + "." + "vulnerabilities.json")
     '''
 
-    licensesAnalysis(args, all_pkgs, url, LCVurl)
+    licensesAnalysis(args, all_pkgs, url, LCVurl, stitched_or_optimized_call_graph)
 
 
 if __name__ == "__main__":

--- a/src/fasten/__main__.py
+++ b/src/fasten/__main__.py
@@ -14,7 +14,7 @@ from enrichCallGraph import EnrichCallGraph
 from stitchedCallGraphAnalyzer import StitchedCallGraphAnalyzer
 from createDirectories import CreateDirectories
 from collectingGeneratedAndRetrievedCallGraphs import collectingGeneratedAndRetrievedCallGraphs
-
+import os, shutil
 
 
 def main():
@@ -37,6 +37,13 @@ def main():
     call_graphs = []
     vulnerabilities = []
 
+    dirs_to_delete = [args.fasten_data, args.scg_path ]
+    for dir in dirs_to_delete :
+        isExist = os.path.exists(dir)
+        if isExist:
+            print("removing: " + dir)
+            shutil.rmtree(dir)
+
     CreateDirectories.DirectoryCheck(args.fasten_data, args.scg_path) # Create directories to store the Call Graphs and the Stitched Call Graph
     DependenciesTree = ExecutePypiResolver.executePypiResolver(args.requirements)
     time.sleep(20)
@@ -48,8 +55,8 @@ def main():
 
     ################################ CALL GRAPHS - Michele - Retrieve and Generation in one function ##################
     call_graphs = collectingGeneratedAndRetrievedCallGraphs(args, all_pkgs, url)
-    print("call_graphs")
-    print(call_graphs)
+    #print("call_graphs")
+    #print(call_graphs)
 
 
     #call_graphs, cg_pkgs = RequestFasten.requestFasten(args, pkgs, url, "rcg")

--- a/src/fasten/collectingGeneratedAndRetrievedCallGraphs.py
+++ b/src/fasten/collectingGeneratedAndRetrievedCallGraphs.py
@@ -12,11 +12,11 @@ def collectingGeneratedAndRetrievedCallGraphs(args, all_pkgs, url):
     GeneratedCallGraphPaths_broken = executeCallGraphGenerator(unknown_call_graphs_and_connectivity_issues, args.fasten_data)#,CallGraphsDirLocal)
     # merging lists of retrieved and generated call graphs location
 
-    mypath = args.fasten_data
-    GeneratedCallGraphPaths = [f for f in listdir(mypath) if isfile(join(mypath, f))]
+    cg_path = args.fasten_data
+    GeneratedCallGraphPaths = [f for f in listdir(cg_path) if isfile(join(cg_path, f))]
     GeneratedCallGraphPaths_mod = []
-    for element in GeneratedCallGraphPaths:
-        element = mypath + "/" + element
-        GeneratedCallGraphPaths_mod.append(element)
+    for cg in GeneratedCallGraphPaths:
+        cg = cg_path + "/" + cg
+        GeneratedCallGraphPaths_mod.append(cg)
     CallGraphsList = GeneratedCallGraphPaths_mod + ReceivedCallGraphsLocation
     return CallGraphsList

--- a/src/fasten/collectingGeneratedAndRetrievedCallGraphs.py
+++ b/src/fasten/collectingGeneratedAndRetrievedCallGraphs.py
@@ -1,0 +1,22 @@
+from executeCallGraphGenerator import executeCallGraphGenerator, deleteCallGraphsDir
+from requestFastenKnownAndUnknownLists import RequestFastenKnownAndUnknownLists
+from os import listdir
+from os.path import isfile, join
+def collectingGeneratedAndRetrievedCallGraphs(args, all_pkgs, url):
+
+    CallGraphsDirLocal = "cg_producing"
+    deleteCallGraphsDir(CallGraphsDirLocal)
+    print("CALL GRAPHS Retrieval:")
+    ReceivedCallGraphsLocation, known_call_graphs, unknown_call_graphs, call_graphs_connectivity_issues = RequestFastenKnownAndUnknownLists.requestFastenKnownAndUnknownLists(args, all_pkgs, url, "rcg")
+    unknown_call_graphs_and_connectivity_issues = {**unknown_call_graphs, **call_graphs_connectivity_issues}
+    GeneratedCallGraphPaths_broken = executeCallGraphGenerator(unknown_call_graphs_and_connectivity_issues, args.fasten_data)#,CallGraphsDirLocal)
+    # merging lists of retrieved and generated call graphs location
+
+    mypath = args.fasten_data
+    GeneratedCallGraphPaths = [f for f in listdir(mypath) if isfile(join(mypath, f))]
+    GeneratedCallGraphPaths_mod = []
+    for element in GeneratedCallGraphPaths:
+        element = mypath + "/" + element
+        GeneratedCallGraphPaths_mod.append(element)
+    CallGraphsList = GeneratedCallGraphPaths_mod + ReceivedCallGraphsLocation
+    return CallGraphsList

--- a/src/fasten/collectingGeneratedAndRetrievedCallGraphs.py
+++ b/src/fasten/collectingGeneratedAndRetrievedCallGraphs.py
@@ -2,6 +2,13 @@ from executeCallGraphGenerator import executeCallGraphGenerator, deleteCallGraph
 from requestFastenKnownAndUnknownLists import RequestFastenKnownAndUnknownLists
 from os import listdir
 from os.path import isfile, join
+
+'''
+* SPDX-FileCopyrightText: 2022 Michele Scarlato <michele.scarlato@endocode.com>
+*
+* SPDX-License-Identifier: Apache-2.0
+'''
+
 def collectingGeneratedAndRetrievedCallGraphs(args, all_pkgs, url):
 
     CallGraphsDirLocal = "cg_producing"

--- a/src/fasten/executeCallGraphGenerator.py
+++ b/src/fasten/executeCallGraphGenerator.py
@@ -3,6 +3,12 @@ import time
 import os.path
 import shutil
 
+'''
+* SPDX-FileCopyrightText: 2022 Michele Scarlato <michele.scarlato@endocode.com>
+*
+* SPDX-License-Identifier: Apache-2.0
+'''
+
 def deleteCallGraphsDir(CallGraphsDirLocal):
     if os.path.exists(CallGraphsDirLocal):
         shutil.rmtree(CallGraphsDirLocal)

--- a/src/fasten/executeCallGraphGenerator.py
+++ b/src/fasten/executeCallGraphGenerator.py
@@ -12,11 +12,16 @@ def deleteCallGraphsDir(CallGraphsDirLocal):
         print("The directory " + CallGraphsDirLocal + " does not exist!")
 
 def executeCallGraphGenerator(unknown_call_graphs, callGraphFastenPath):
-    CallGraphsDirLocal = "directoryName"
+    CallGraphsDirLocal = "cg_sources_dir"
+
+    isExist = os.path.exists(CallGraphsDirLocal)
+    if isExist:
+        shutil.rmtree(CallGraphsDirLocal)
+
     global CallGraphPaths
     CallGraphPaths = []
     for key in unknown_call_graphs:
-        print(key, unknown_call_graphs[key])
+        #print(key, unknown_call_graphs[key])
         packageName = key
         packageVersion = unknown_call_graphs[key]
 
@@ -33,18 +38,22 @@ def executeCallGraphGenerator(unknown_call_graphs, callGraphFastenPath):
 def executeSingleCallGraphGeneration(coord, packageName, packageVersion, directoryName, CallGraphPathLocal,callGraphFastenPath):
 
     generator = CallGraphGenerator(directoryName, coord)
-    print(generator.generate())
     # wait for the call graph to be generated
-    print("Waiting for call graph generation at: ")
-    print(CallGraphPathLocal)
+    #print("Waiting for call graph generation at: ")
+    #print(CallGraphPathLocal)
     timer = 1
     global CallGraphPaths
     CallGraphPaths = []
     while not os.path.exists(CallGraphPathLocal):
         time.sleep(1)
         timer += 1
-        if timer > 30:
-            print(""+str(timer)+" seconds without call graph generation passed.")
+        if timer > 60:
+            print("" + str(timer) + " seconds without call graph generation passed.")
+            # print the status
+            dict = generator.generate()
+            print(dict.get("Status"))
+            #print(dict)
+            #print(generator.generate())
             break
     if os.path.isfile(CallGraphPathLocal):
         print("Call graph generated at: "+CallGraphPathLocal)

--- a/src/fasten/executeCallGraphGenerator.py
+++ b/src/fasten/executeCallGraphGenerator.py
@@ -1,0 +1,57 @@
+from pycg_producer.producer import CallGraphGenerator
+import time
+import os.path
+import shutil
+
+def deleteCallGraphsDir(CallGraphsDirLocal):
+    if os.path.exists(CallGraphsDirLocal):
+        shutil.rmtree(CallGraphsDirLocal)
+        print("The directory " + CallGraphsDirLocal + " has been deleted successfully")
+        time.sleep(10)
+    else:
+        print("The directory " + CallGraphsDirLocal + " does not exist!")
+
+def executeCallGraphGenerator(unknown_call_graphs, callGraphFastenPath):
+    CallGraphsDirLocal = "directoryName"
+    global CallGraphPaths
+    CallGraphPaths = []
+    for key in unknown_call_graphs:
+        print(key, unknown_call_graphs[key])
+        packageName = key
+        packageVersion = unknown_call_graphs[key]
+
+        coord = { "product": ""+packageName+"",
+              "version": ""+packageVersion+"",
+              "version_timestamp": "2000",
+              "requires_dist": []}
+
+        CallGraphPathLocal = CallGraphsDirLocal + "/" + "callgraphs"+ "/" + packageName[0] + "/" + packageName + "/" + packageVersion + "/" + "cg.json"
+        executeSingleCallGraphGeneration(coord, packageName, packageVersion, CallGraphsDirLocal, CallGraphPathLocal, callGraphFastenPath)
+    return CallGraphPaths
+
+
+def executeSingleCallGraphGeneration(coord, packageName, packageVersion, directoryName, CallGraphPathLocal,callGraphFastenPath):
+
+    generator = CallGraphGenerator(directoryName, coord)
+    print(generator.generate())
+    # wait for the call graph to be generated
+    print("Waiting for call graph generation at: ")
+    print(CallGraphPathLocal)
+    timer = 1
+    global CallGraphPaths
+    CallGraphPaths = []
+    while not os.path.exists(CallGraphPathLocal):
+        time.sleep(1)
+        timer += 1
+        if timer > 30:
+            print(""+str(timer)+" seconds without call graph generation passed.")
+            break
+    if os.path.isfile(CallGraphPathLocal):
+        print("Call graph generated at: "+CallGraphPathLocal)
+        CallGraphPathLocalRenamed = CallGraphPathLocal.replace("cg.json", packageName+"-"+packageVersion+".json")
+        os.rename(CallGraphPathLocal, CallGraphPathLocalRenamed)
+        shutil.copy(CallGraphPathLocalRenamed, callGraphFastenPath )
+        CallGraphPaths.append(callGraphFastenPath+"/"+packageName+"-"+packageVersion+".json")
+        pass
+    else:
+        print("%s has not been generated!" % CallGraphPathLocal)

--- a/src/fasten/executePypiResolver.py
+++ b/src/fasten/executePypiResolver.py
@@ -2,6 +2,12 @@ import time
 import os
 import pypiResolver
 
+'''
+* SPDX-FileCopyrightText: 2022 Michele Scarlato <michele.scarlato@endocode.com>
+*
+* SPDX-License-Identifier: Apache-2.0
+'''
+
 class ExecutePypiResolver:
 
     @staticmethod

--- a/src/fasten/gitHubAndPyPIParsingUtils.py
+++ b/src/fasten/gitHubAndPyPIParsingUtils.py
@@ -9,17 +9,16 @@ def retrieveGitHubUrl(jsonResponse, packageName):
     url = ""
     response = json.dumps(jsonResponse)
     data = json.loads(response)
-    #JSONKeysList = ['home_page']
-
     if packageName in data['info']['home_page']:
         if "https://github.com/" in data['info']['home_page']:
             url = data['info']['home_page']
             return url
-    if 'Homepage' in data['info']['project_urls']:
-        if packageName in data['info']['project_urls']['Homepage']:
-            if "https://github.com/" in data['info']['project_urls']['Homepage']:
-                url = data['info']['home_page']
-                return url
+    if data['info']['project_urls'] != None:
+        if 'Homepage' in data['info']['project_urls']:
+            if packageName in data['info']['project_urls']['Homepage']:
+                if "https://github.com/" in data['info']['project_urls']['Homepage']:
+                    url = data['info']['home_page']
+                    return url
     iterdict(data, packageName)
     return url
 
@@ -150,4 +149,4 @@ def retrieveLicenseInformationFromPyPI(packageName, packageVersion, LCVurl):
     except requests.exceptions.ConnectionError:
         print('Connection timeout: ConnectError')
         time.sleep(30)
-    return PyPILicense, PyPILicenseSPDX, jsonResponse
+    return PyPILicenseSPDX, PyPILicenseSPDX, jsonResponse

--- a/src/fasten/gitHubAndPyPIParsingUtils.py
+++ b/src/fasten/gitHubAndPyPIParsingUtils.py
@@ -1,0 +1,153 @@
+import json
+import requests
+import time
+from urllib.parse import urlparse
+
+
+def retrieveGitHubUrl(jsonResponse, packageName):
+    global url
+    url = ""
+    response = json.dumps(jsonResponse)
+    data = json.loads(response)
+    #JSONKeysList = ['home_page']
+
+    if packageName in data['info']['home_page']:
+        if "https://github.com/" in data['info']['home_page']:
+            url = data['info']['home_page']
+            return url
+    if 'Homepage' in data['info']['project_urls']:
+        if packageName in data['info']['project_urls']['Homepage']:
+            if "https://github.com/" in data['info']['project_urls']['Homepage']:
+                url = data['info']['home_page']
+                return url
+    iterdict(data, packageName)
+    return url
+
+def iterdict (d,packageName):
+    #print(packageName)
+    global url
+    for k,v in d.items():
+        if k != "description":
+            if isinstance(v, dict):
+                iterdict(v,packageName)
+            else:
+                if "https://github.com/" in str(v):
+                    if packageName in str(v):
+                        url = str(v)
+                        return url
+
+def RetrieveGitHubAPIurl(GitHubURL):
+    parts = urlparse(GitHubURL)
+    #print(parts)
+    directories = parts.path.strip('/').split('/')
+    #print(directories)
+    owner = directories[0]
+    repo = directories[1]
+    GitHubAPIurl = "https://api.github.com/repos/" + owner + "/" + repo + "/license"
+    return GitHubAPIurl
+
+def RetrieveLicenseFromGitHub(GitHubAPIurl, LCVurl):
+    #print(GitHubAPIurl)
+    GitHubLicense = ""
+    GitHubLicenseSPDX = ""
+    try:
+        response = requests.get(url=GitHubAPIurl)  # get Call Graph for specified package
+        if response.status_code == 200:
+            jsonResponse = response.json()  # save Call Graph as JSON format
+            GitHubLicense = (jsonResponse["license"]["spdx_id"])
+            if len(GitHubLicense) == 0:
+                GitHubLicense = (jsonResponse["license"]["key"])
+            if len(GitHubLicense) == 0:
+                GitHubLicense = (jsonResponse["license"]["name"])
+            # here a call to the LCV endpoint convertToSPDX endpoint should be performed
+            if len(GitHubLicense) > 0:
+                # check if the retrieved license is an SPDX id
+                IsSPDX = IsAnSPDX(GitHubLicense, LCVurl)
+                if IsSPDX == False:
+                    #print("converting to SPDX")
+                    SPDXConversion = ConvertToSPDX(GitHubLicense, LCVurl)
+                    IsSPDX = IsAnSPDX(SPDXConversion, LCVurl)
+                    if IsSPDX == True:
+                        GitHubLicenseSPDX = SPDXConversion
+                else :
+                    GitHubLicenseSPDX = GitHubLicense
+    except requests.exceptions.ReadTimeout:
+        print('Connection timeout: ReadTimeout')
+    except requests.exceptions.ConnectTimeout:
+        print('Connection timeout: ConnectTimeout')
+    except requests.exceptions.ConnectionError:
+        print('Connection timeout: ConnectError')
+        time.sleep(30)
+    #if GitHubLicense != "":
+    return GitHubLicense, GitHubLicenseSPDX
+    #else:
+     #   return
+
+def IsAnSPDX(License, LCVurl):
+    LCVIsAnSPDXJsonResponse = None
+    LCVIsAnSPDXurl = LCVurl + "IsAnSPDX?SPDXid=" + License
+    #print(LCVIsAnSPDXurl)
+    try:
+        response = requests.get(url=LCVIsAnSPDXurl)  # get Call Graph for specified package
+        if response.status_code == 200:
+            LCVIsAnSPDXJsonResponse = response.json()
+            #print("SPDX id is an SPDX? ")
+            #print(LCVIsAnSPDXJsonResponse)
+    except requests.exceptions.ReadTimeout:
+        print('Connection timeout: ReadTimeout')
+    except requests.exceptions.ConnectTimeout:
+        print('Connection timeout: ConnectTimeout')
+    except requests.exceptions.ConnectionError:
+        print('Connection timeout: ConnectError')
+        time.sleep(30)
+    return LCVIsAnSPDXJsonResponse
+
+def ConvertToSPDX(License, LCVurl):
+    LCVConvertToSPDXurl = LCVurl + "ConvertToSPDX?VerboseLicense=" + License
+    try:
+        response = requests.get(url=LCVConvertToSPDXurl)  # get Call Graph for specified package
+        if response.status_code == 200:
+            LCVConvertToSPDXJsonResponse = response.json()
+            #print("SPDX id retrieved by LCV:")
+            #print(LCVConvertToSPDXJsonResponse)
+    except requests.exceptions.ReadTimeout:
+        print('Connection timeout: ReadTimeout')
+    except requests.exceptions.ConnectTimeout:
+        print('Connection timeout: ConnectTimeout')
+    except requests.exceptions.ConnectionError:
+        print('Connection timeout: ConnectError')
+        time.sleep(30)
+    return LCVConvertToSPDXJsonResponse
+
+def retrieveLicenseInformationFromPyPI(packageName, packageVersion, LCVurl):
+    print("Querying PyPI.org APIs for license information:")
+    #pkgs = json.loads(pkgs)
+    URL = "https://pypi.org/" + "pypi/" + packageName + "/" + packageVersion + "/json"
+    print(URL)
+    PyPILicenseSPDX = ""
+    try:
+        response = requests.get(url=URL)  # get Call Graph for specified package
+        if response.status_code == 200:
+            jsonResponse = response.json()  # save Call Graph as JSON format
+            PyPILicense = (jsonResponse["info"]["license"])
+            # here a call to the LCV endpoint convertToSPDX endpoint should be performed
+            if len(PyPILicense) > 0:
+                # check if the retrieved license is an SPDX id
+                IsSPDX = IsAnSPDX(PyPILicense, LCVurl)
+                if IsSPDX == False:
+                    print("converting " +PyPILicense + " to SPDX")
+                    SPDXConversion = ConvertToSPDX(PyPILicense, LCVurl)
+                    IsSPDX = IsAnSPDX(SPDXConversion, LCVurl)
+                    if IsSPDX == True:
+                        PyPILicenseSPDX = SPDXConversion
+                        print(PyPILicense + " converted into " + SPDXConversion )
+                else:
+                    PyPILicenseSPDX = PyPILicense
+    except requests.exceptions.ReadTimeout:
+        print('Connection timeout: ReadTimeout')
+    except requests.exceptions.ConnectTimeout:
+        print('Connection timeout: ConnectTimeout')
+    except requests.exceptions.ConnectionError:
+        print('Connection timeout: ConnectError')
+        time.sleep(30)
+    return PyPILicense, PyPILicenseSPDX, jsonResponse

--- a/src/fasten/gitHubAndPyPIParsingUtils.py
+++ b/src/fasten/gitHubAndPyPIParsingUtils.py
@@ -3,6 +3,11 @@ import requests
 import time
 from urllib.parse import urlparse
 
+'''
+* SPDX-FileCopyrightText: 2022 Michele Scarlato <michele.scarlato@endocode.com>
+*
+* SPDX-License-Identifier: Apache-2.0
+'''
 
 def retrieveGitHubUrl(jsonResponse, packageName):
     global url
@@ -23,7 +28,6 @@ def retrieveGitHubUrl(jsonResponse, packageName):
     return url
 
 def iterdict (d,packageName):
-    #print(packageName)
     global url
     for k,v in d.items():
         if k != "description":
@@ -37,16 +41,13 @@ def iterdict (d,packageName):
 
 def RetrieveGitHubAPIurl(GitHubURL):
     parts = urlparse(GitHubURL)
-    #print(parts)
     directories = parts.path.strip('/').split('/')
-    #print(directories)
     owner = directories[0]
     repo = directories[1]
     GitHubAPIurl = "https://api.github.com/repos/" + owner + "/" + repo + "/license"
     return GitHubAPIurl
 
 def RetrieveLicenseFromGitHub(GitHubAPIurl, LCVurl):
-    #print(GitHubAPIurl)
     GitHubLicense = ""
     GitHubLicenseSPDX = ""
     try:
@@ -63,7 +64,6 @@ def RetrieveLicenseFromGitHub(GitHubAPIurl, LCVurl):
                 # check if the retrieved license is an SPDX id
                 IsSPDX = IsAnSPDX(GitHubLicense, LCVurl)
                 if IsSPDX == False:
-                    #print("converting to SPDX")
                     SPDXConversion = ConvertToSPDX(GitHubLicense, LCVurl)
                     IsSPDX = IsAnSPDX(SPDXConversion, LCVurl)
                     if IsSPDX == True:
@@ -77,21 +77,16 @@ def RetrieveLicenseFromGitHub(GitHubAPIurl, LCVurl):
     except requests.exceptions.ConnectionError:
         print('Connection timeout: ConnectError')
         time.sleep(30)
-    #if GitHubLicense != "":
+
     return GitHubLicense, GitHubLicenseSPDX
-    #else:
-     #   return
 
 def IsAnSPDX(License, LCVurl):
     LCVIsAnSPDXJsonResponse = None
     LCVIsAnSPDXurl = LCVurl + "IsAnSPDX?SPDXid=" + License
-    #print(LCVIsAnSPDXurl)
     try:
         response = requests.get(url=LCVIsAnSPDXurl)  # get Call Graph for specified package
         if response.status_code == 200:
             LCVIsAnSPDXJsonResponse = response.json()
-            #print("SPDX id is an SPDX? ")
-            #print(LCVIsAnSPDXJsonResponse)
     except requests.exceptions.ReadTimeout:
         print('Connection timeout: ReadTimeout')
     except requests.exceptions.ConnectTimeout:
@@ -107,8 +102,6 @@ def ConvertToSPDX(License, LCVurl):
         response = requests.get(url=LCVConvertToSPDXurl)  # get Call Graph for specified package
         if response.status_code == 200:
             LCVConvertToSPDXJsonResponse = response.json()
-            #print("SPDX id retrieved by LCV:")
-            #print(LCVConvertToSPDXJsonResponse)
     except requests.exceptions.ReadTimeout:
         print('Connection timeout: ReadTimeout')
     except requests.exceptions.ConnectTimeout:
@@ -120,16 +113,14 @@ def ConvertToSPDX(License, LCVurl):
 
 def retrieveLicenseInformationFromPyPI(packageName, packageVersion, LCVurl):
     print("Querying PyPI.org APIs for license information:")
-    #pkgs = json.loads(pkgs)
     URL = "https://pypi.org/" + "pypi/" + packageName + "/" + packageVersion + "/json"
     print(URL)
     PyPILicenseSPDX = ""
     try:
-        response = requests.get(url=URL)  # get Call Graph for specified package
+        response = requests.get(url=URL)
         if response.status_code == 200:
-            jsonResponse = response.json()  # save Call Graph as JSON format
+            jsonResponse = response.json()
             PyPILicense = (jsonResponse["info"]["license"])
-            # here a call to the LCV endpoint convertToSPDX endpoint should be performed
             if len(PyPILicense) > 0:
                 # check if the retrieved license is an SPDX id
                 IsSPDX = IsAnSPDX(PyPILicense, LCVurl)

--- a/src/fasten/licenseComplianceVerification.py
+++ b/src/fasten/licenseComplianceVerification.py
@@ -1,0 +1,67 @@
+import json
+import time
+import requests
+from gitHubAndPyPIParsingUtils import IsAnSPDX
+
+
+def licenseComplianceVerification(InboundLicenses, OutboundLicense, LCVurl):
+    InboundLicensesString = ';'.join([str(item) for item in InboundLicenses])
+    print ("InboundLicensesString:")
+    print(InboundLicensesString)
+    LCVComplianceAssessment = LCVurl + "LicensesInput?InboundLicenses=" + InboundLicensesString + "&OutboundLicense=" + OutboundLicense
+    try:
+        response = requests.get(url=LCVComplianceAssessment)  # get Call Graph for specified package
+        if response.status_code == 200:
+            LCVComplianceAssessmentResponse = response.json()
+
+    except requests.exceptions.ReadTimeout:
+        print('Connection timeout: ReadTimeout')
+    except requests.exceptions.ConnectTimeout:
+        print('Connection timeout: ConnectTimeout')
+    except requests.exceptions.ConnectionError:
+        print('Connection timeout: ConnectError')
+        time.sleep(30)
+    return LCVComplianceAssessmentResponse
+
+def generateInboundLicenses(licenses, LCVurl):
+
+    InboundLicenses = []
+
+    for i in licenses:
+
+        PyPILicenseSPDX = licenses[i].get("PyPILicenseSPDX")
+
+        if len(PyPILicenseSPDX) > 0:
+            InboundLicenses.append(PyPILicenseSPDX)
+        else:
+            GitHubLicenseSPDX = licenses[i].get("GitHubLicense")
+            if len(GitHubLicenseSPDX) > 0:
+                InboundLicenses.append(GitHubLicenseSPDX)
+    return InboundLicenses
+
+def parseLCVAssessmentResponse(LCVAssessmentResponseList, licenses):
+    #LCVAssessmentResponse = json.loads(LCVAssessmentResponseJSON)
+    assessment = []
+    #print(licenses)
+    for dict in LCVAssessmentResponseList:
+        if (dict.get("status")) == "not compatible":
+            InboundNotCompatibleLicense = (dict.get("inbound_SPDX"))
+            outputNotCompatibleInboundLicense = (dict.get("message"))
+            for i in licenses:
+                packageName = licenses[i].get("packageName")
+                packageVersion = licenses[i].get("packageVersion")
+                if licenses[i].get("PyPILicenseSPDX") == InboundNotCompatibleLicense:
+                    outputPackageInformationNotCompatibleInboundLicensePyPI = "License " + InboundNotCompatibleLicense + \
+                        ", declared in PyPI, found in " + packageName + " v. " + packageVersion + "."
+                    assessment.append(outputPackageInformationNotCompatibleInboundLicensePyPI)
+                if licenses[i].get("GitHubLicense") == InboundNotCompatibleLicense:
+                    outputPackageInformationNotCompatibleInboundLicenseGitHub = "License " + InboundNotCompatibleLicense + \
+                        " declared in GitHub found in " + packageName + " v. " + packageVersion + "."
+                    "."
+                    assessment.append(outputPackageInformationNotCompatibleInboundLicenseGitHub)
+            assessment.append(outputNotCompatibleInboundLicense)
+
+        #status = LCVAssessmentResponse[i].get("status")
+    return assessment
+
+#def provideReport(LicenseReport, licenses):

--- a/src/fasten/licenseComplianceVerification.py
+++ b/src/fasten/licenseComplianceVerification.py
@@ -31,11 +31,11 @@ def generateInboundLicenses(licenses, LCVurl):
 
         PyPILicenseSPDX = licenses[i].get("PyPILicenseSPDX")
 
-        if len(PyPILicenseSPDX) > 0:
+        if PyPILicenseSPDX != None:
             InboundLicenses.append(PyPILicenseSPDX)
         else:
             GitHubLicenseSPDX = licenses[i].get("GitHubLicense")
-            if len(GitHubLicenseSPDX) > 0:
+            if GitHubLicenseSPDX != None:
                 InboundLicenses.append(GitHubLicenseSPDX)
     return InboundLicenses
 
@@ -61,7 +61,10 @@ def parseLCVAssessmentResponse(LCVAssessmentResponseList, licenses):
                     assessment.append(outputPackageInformationNotCompatibleInboundLicenseGitHub)
             assessment.append(outputNotCompatibleInboundLicense)
 
-        #status = LCVAssessmentResponse[i].get("status")
+
+    if len(assessment) == 0:
+        output = "Licensing issues at the package level have not been found"
+        assessment.append(output)
     return assessment
 
 #def provideReport(LicenseReport, licenses):

--- a/src/fasten/licenseComplianceVerification.py
+++ b/src/fasten/licenseComplianceVerification.py
@@ -6,8 +6,6 @@ from gitHubAndPyPIParsingUtils import IsAnSPDX
 
 def licenseComplianceVerification(InboundLicenses, OutboundLicense, LCVurl):
     InboundLicensesString = ';'.join([str(item) for item in InboundLicenses])
-    print ("InboundLicensesString:")
-    print(InboundLicensesString)
     LCVComplianceAssessment = LCVurl + "LicensesInput?InboundLicenses=" + InboundLicensesString + "&OutboundLicense=" + OutboundLicense
     try:
         response = requests.get(url=LCVComplianceAssessment)  # get Call Graph for specified package
@@ -31,18 +29,18 @@ def generateInboundLicenses(licenses, LCVurl):
 
         PyPILicenseSPDX = licenses[i].get("PyPILicenseSPDX")
 
-        if PyPILicenseSPDX != None:
+        if PyPILicenseSPDX is not None:
             InboundLicenses.append(PyPILicenseSPDX)
         else:
             GitHubLicenseSPDX = licenses[i].get("GitHubLicense")
-            if GitHubLicenseSPDX != None:
+            if GitHubLicenseSPDX is not None:
                 InboundLicenses.append(GitHubLicenseSPDX)
     return InboundLicenses
 
 def parseLCVAssessmentResponse(LCVAssessmentResponseList, licenses):
-    #LCVAssessmentResponse = json.loads(LCVAssessmentResponseJSON)
+    # LCVAssessmentResponse = json.loads(LCVAssessmentResponseJSON)
     assessment = []
-    #print(licenses)
+    # print(licenses)
     for dict in LCVAssessmentResponseList:
         if (dict.get("status")) == "not compatible":
             InboundNotCompatibleLicense = (dict.get("inbound_SPDX"))
@@ -67,4 +65,4 @@ def parseLCVAssessmentResponse(LCVAssessmentResponseList, licenses):
         assessment.append(output)
     return assessment
 
-#def provideReport(LicenseReport, licenses):
+# def provideReport(LicenseReport, licenses):

--- a/src/fasten/licensesAnalysis.py
+++ b/src/fasten/licensesAnalysis.py
@@ -9,7 +9,7 @@ from licensesApplicationToTheStitchedCallGraph import licensesAtThePackageLevelA
 * SPDX-License-Identifier: Apache-2.0
 '''
 
-def licensesAnalysis(args, all_pkgs, url, LCVurl):
+def licensesAnalysis(args, all_pkgs, url, LCVurl, stitched_call_graph):
     licenses_retrieved_from_fasten, licenses_retrieved_locally, licenses_retrieved_at_the_file_level = retrieveLicenseInformation(args, all_pkgs, url, LCVurl)
     licenses_retrieved = {**licenses_retrieved_from_fasten, **licenses_retrieved_locally}
     InboundLicenses = generateInboundLicenses(licenses_retrieved)
@@ -25,8 +25,9 @@ def licensesAnalysis(args, all_pkgs, url, LCVurl):
             print(LicenseReport[i]["licenseViolation"])
 
 
-
+    #to be changed with the correct path
     stitched_call_graph = "pipup_long.json"
+
     callablesEnrichedWithLicenseInformation = licensesAtThePackageLevelApplicationToTheStitchedCallGraph(stitched_call_graph, licenses_retrieved)
 
     callablesEnrichedWithLicenseAtTheFileLevel = licensesAtTheFileLevelApplicationToTheStitchedCallGraph(licenses_retrieved_at_the_file_level, stitched_call_graph)

--- a/src/fasten/licensesAnalysis.py
+++ b/src/fasten/licensesAnalysis.py
@@ -19,10 +19,10 @@ def licensesAnalysis(args, all_pkgs, url, LCVurl):
     if len(LicenseReport) > 0:
         print("License violation found at the package level: " +str(len(LicenseReport)) + " ." )
         for i in LicenseReport:
+            print("\n")
             print("############# - violation number " + str(i + 1) + " #################")
             print(LicenseReport[i]["packageInformation"])
             print(LicenseReport[i]["licenseViolation"])
-            print("\n")
 
 
 

--- a/src/fasten/licensesAnalysis.py
+++ b/src/fasten/licensesAnalysis.py
@@ -1,0 +1,55 @@
+import json
+from retrieveLicenseInformation import retrieveLicenseInformation
+from licenseComplianceVerification import generateInboundLicenses, licenseComplianceVerification, parseLCVAssessmentResponse#, provideReport
+from licensesApplicationToTheStitchedCallGraph import licensesAtThePackageLevelApplicationToTheStitchedCallGraph, licensesAtTheFileLevelApplicationToTheStitchedCallGraph, LCVAssessmentAtTheFileLevel, LCVAssessmentAtTheFileLevelGenerateReport, CompareLicensesAtThePackageLevelWithTheFileLevel
+
+'''
+* SPDX-FileCopyrightText: 2022 Michele Scarlato <michele.scarlato@endocode.com>
+*
+* SPDX-License-Identifier: Apache-2.0
+'''
+
+def licensesAnalysis(args, all_pkgs, url, LCVurl):
+    licenses_retrieved_from_fasten, licenses_retrieved_locally, licenses_retrieved_at_the_file_level = retrieveLicenseInformation(args, all_pkgs, url, LCVurl)
+    licenses_retrieved = {**licenses_retrieved_from_fasten, **licenses_retrieved_locally}
+    InboundLicenses = generateInboundLicenses(licenses_retrieved)
+    OutboundLicense = args.spdx_license
+    LCVAssessmentResponse = licenseComplianceVerification(InboundLicenses, OutboundLicense, LCVurl)
+    LicenseReport = parseLCVAssessmentResponse(LCVAssessmentResponse, licenses_retrieved)
+    if len(LicenseReport) > 0:
+        print("License violation found at the package level: " +str(len(LicenseReport)) + " ." )
+        for i in LicenseReport:
+            print("############# - violation number " + str(i + 1) + " #################")
+            print(LicenseReport[i]["packageInformation"])
+            print(LicenseReport[i]["licenseViolation"])
+            print("\n")
+
+
+
+    stitched_call_graph = "pipup_long.json"
+    callablesEnrichedWithLicenseInformation = licensesAtThePackageLevelApplicationToTheStitchedCallGraph(stitched_call_graph, licenses_retrieved)
+
+    callablesEnrichedWithLicenseAtTheFileLevel = licensesAtTheFileLevelApplicationToTheStitchedCallGraph(licenses_retrieved_at_the_file_level, stitched_call_graph)
+
+    callablesWithLicenseViolationParsed = LCVAssessmentAtTheFileLevel(callablesEnrichedWithLicenseAtTheFileLevel, OutboundLicense, LCVurl)
+
+    LCVAssessmentAtTheFileLevelReport = LCVAssessmentAtTheFileLevelGenerateReport(callablesWithLicenseViolationParsed)
+
+    if len(LCVAssessmentAtTheFileLevelReport) > 0:
+        print("\n")
+        print("License compliance assessment at the file level:")
+        for i in LCVAssessmentAtTheFileLevelReport:
+            print(i)
+    else:
+        print("\n")
+        print("The license compliance assessment at the file level doesn't detect licenses issues.")
+
+    ReportLicensesPackageComparedWithFile = CompareLicensesAtThePackageLevelWithTheFileLevel(licenses_retrieved, licenses_retrieved_at_the_file_level)
+
+    if len(ReportLicensesPackageComparedWithFile) > 0:
+        print("\n")
+        print("Report upon incompatible licenses: scancode detected file licenses compared with the license declared at the package level:")
+        print(ReportLicensesPackageComparedWithFile)
+    else:
+        print("\n")
+        print("The report upon incompatible licenses between files and package didn't show incompatibilities.")

--- a/src/fasten/licensesApplicationToTheStitchedCallGraph.py
+++ b/src/fasten/licensesApplicationToTheStitchedCallGraph.py
@@ -1,0 +1,40 @@
+import json
+import re
+
+def licensesApplicationToTheStitchedCallGraph(stitched_call_graph, licenses_retrieved_from_fasten_at_files_level, licenses_retrieved_at_the_package_level ):
+    callablesReportedForLicenseViolation = {}
+    callablesEnrichedWithLicenseInformation = {}
+    f = open(stitched_call_graph)
+    data = json.load(f)
+    LicensePackagesList = []
+
+    print(licenses_retrieved_at_the_package_level)
+
+    for j in licenses_retrieved_at_the_package_level:
+        LicensePackagesList.append(licenses_retrieved_at_the_package_level[j]["packageName"])
+
+    for i in data["nodes"]:
+        callablesEnrichedWithLicenseInformation[i] = {}
+        for element in LicensePackagesList:
+            # look for package name inside of the URI
+            URI = data["nodes"][i]["URI"]
+            # extract the package name from the URI
+            packageNameMatch = re.findall("(?<=\!)(.*?)(?=\$)", URI)
+            # match the package name in the URI, using ! and $ as a delimiter
+            if packageNameMatch[0] == element:
+                callablesEnrichedWithLicenseInformation[i]["URI"] = URI
+                print(element + " found in " + str(URI))
+                for j in licenses_retrieved_at_the_package_level:
+                    # look for package name inside of the licenses package level
+                    if element in licenses_retrieved_at_the_package_level[j]["packageName"]:
+                        if "PyPILicenseSPDX" in licenses_retrieved_at_the_package_level[j]:
+                            callablesEnrichedWithLicenseInformation[i]["PyPILicenseSPDX_at_package_level"] = licenses_retrieved_at_the_package_level[j]["PyPILicenseSPDX"]
+                            print(callablesEnrichedWithLicenseInformation[i]["PyPILicenseSPDX_at_package_level"])
+                        else:
+                            if "GitHubLicenseSPDX" in licenses_retrieved_at_the_package_level[j]:
+                                callablesEnrichedWithLicenseInformation[i]["GitHubLicenseSPDX_at_package_level"] = licenses_retrieved_at_the_package_level[j]["GitHubLicenseSPDX"]
+                                print(callablesEnrichedWithLicenseInformation[i]["GitHubLicenseSPDX_at_package_level"])
+    #print("callablesEnrichedWithLicenseInformation:")
+    #print(callablesEnrichedWithLicenseInformation)
+
+    return callablesEnrichedWithLicenseInformation

--- a/src/fasten/licensesApplicationToTheStitchedCallGraph.py
+++ b/src/fasten/licensesApplicationToTheStitchedCallGraph.py
@@ -1,3 +1,4 @@
+from licenseComplianceVerification import parseLCVAssessmentResponse, licenseComplianceVerification
 import json
 import re
 
@@ -44,7 +45,7 @@ def licensesAtThePackageLevelApplicationToTheStitchedCallGraph(stitched_call_gra
 
     return callablesEnrichedWithLicenseInformation
 
-def licensesAtTheFileLevelApplicationToTheStitchedCallGraph(licenses_retrieved_at_the_file_level, callablesEnrichedWithLicenseInformation, stitched_call_graph):
+def licensesAtTheFileLevelApplicationToTheStitchedCallGraph(licenses_retrieved_at_the_file_level, stitched_call_graph):
     callablesEnrichedWithLicenseAtFileLevel = {}
     # loading the stitch call graph
     f = open(stitched_call_graph)
@@ -70,21 +71,118 @@ def licensesAtTheFileLevelApplicationToTheStitchedCallGraph(licenses_retrieved_a
         for j in licenses_retrieved_at_the_file_level:
             for k in licenses_retrieved_at_the_file_level[j]:
                 if "packageName" in licenses_retrieved_at_the_file_level[j][k]:
-                    print(licenses_retrieved_at_the_file_level[j][k]["packageName"])
+                    # print(licenses_retrieved_at_the_file_level[j][k]["packageName"])
                     # match the package name in the URI, using ! and $ as a delimiter - against the licenses at file level list
                     if packageNameMatch[0] == licenses_retrieved_at_the_file_level[j][k]["packageName"]:
                         # path conversion into fasten cg format
                         path = licenses_retrieved_at_the_file_level[j][k]["path"]
                         path = path.replace("/",".")
                         path = path.replace(".py","")
-                        print(path)
+                        #print(path)
                         if path in URI:
                             callablesEnrichedWithLicenseAtFileLevel[i] = {}
                             callablesEnrichedWithLicenseAtFileLevel[i]["URI"] = URI
                             # here should go a check for all the keys with spdx_license_key_
-                            callablesEnrichedWithLicenseAtFileLevel[i]["SPDX_license_at_the_file_level"] = \
-                            licenses_retrieved_at_the_file_level[j][k]["spdx_license_key_1"]
+                            callablesEnrichedWithLicenseAtFileLevel[i]["SPDX_license_at_the_file_level"] = []
+                            for license in licenses_retrieved_at_the_file_level[j][k]["spdx_license_key"]:
+                                callablesEnrichedWithLicenseAtFileLevel[i]["SPDX_license_at_the_file_level"].append(license)#licenses_retrieved_at_the_file_level[j][k]["spdx_license_key"][])
     with open('callablesEnrichedWithLicenseAtFileLevel.json', 'w') as convert_file:
         json.dump(callablesEnrichedWithLicenseAtFileLevel, convert_file, indent=4)
 
     return callablesEnrichedWithLicenseAtFileLevel
+
+def LCVAssessmentAtTheFileLevel(callablesEnrichedWithLicenseAtTheFileLevel, OutboundLicense, LCVurl):
+
+    data = callablesEnrichedWithLicenseAtTheFileLevel
+    callablesWithLicenseViolation = {}
+    # considering that only 1 license is detected for a file
+    for i in data:
+        InboundLicense = data[i]["SPDX_license_at_the_file_level"]
+        LCVResponse = licenseComplianceVerification(InboundLicense, OutboundLicense, LCVurl)
+        if len(LCVResponse) == 0:
+            pass
+        if "it is the same of the outbound license" in LCVResponse[0]:
+            pass
+        else:
+            callablesWithLicenseViolation[i] = {}
+            callablesWithLicenseViolation[i] = LCVResponse[0]
+            callablesWithLicenseViolation[i]["URI"] = data[i]["URI"]
+
+    with open('callablesWithLicenseViolation.json', 'w') as convert_file:
+        json.dump(callablesWithLicenseViolation, convert_file, indent=4)
+
+    callablesWithLicenseViolationParsed = {}
+
+    for i in callablesWithLicenseViolation:
+        if callablesWithLicenseViolation[i]["status"] == "not compatible":
+            callablesWithLicenseViolationParsed[i] = {}
+            callablesWithLicenseViolationParsed[i]["URI"] = callablesWithLicenseViolation[i]["URI"]
+            callablesWithLicenseViolationParsed[i]["message"] = callablesWithLicenseViolation[i]["message"]
+            callablesWithLicenseViolationParsed[i]["inbound_SPDX"] = callablesWithLicenseViolation[i]["inbound_SPDX"]
+            callablesWithLicenseViolationParsed[i]["outbound_SPDX"] = callablesWithLicenseViolation[i]["outbound_SPDX"]
+
+    with open('callablesWithLicenseViolationParsed.json', 'w') as convert_file:
+        json.dump(callablesWithLicenseViolation, convert_file, indent=4)
+
+    return callablesWithLicenseViolationParsed
+
+
+
+def LCVAssessmentAtTheFileLevelGenerateReport(callablesWithLicenseViolationParsed):
+    LCVAssessmentAtTheFileLevelReport = []
+    for i in callablesWithLicenseViolationParsed:
+        output = (str(callablesWithLicenseViolationParsed[i]["URI"]) + " detected with " + str(callablesWithLicenseViolationParsed[i]["inbound_SPDX"]) + " " + \
+                  " as a declared license (found with Scancode, from the FASTEN server) " + ". " + str(callablesWithLicenseViolationParsed[i]["inbound_SPDX"]) + " is not compatible with " + \
+                " " + str(callablesWithLicenseViolationParsed[i]["outbound_SPDX"]) + " declared as the outbound license .")
+        LCVAssessmentAtTheFileLevelReport.append(output)
+
+    with open(r'LCVAssessmentAtTheFileLevelReport.txt', 'w') as fp:
+        for item in LCVAssessmentAtTheFileLevelReport:
+            # write each item on a new line
+            fp.write("%s\n" % item)
+
+    return LCVAssessmentAtTheFileLevelReport
+
+
+# this method should be reviewed since now the licenses at the file level are a list
+def CompareLicensesAtThePackageLevelWithTheFileLevel(licenses_retrieved_data, licenses_retrieved_at_the_file_level):
+    ReportLicensesPackageComparedWithFile = {}
+    z = 0 # Report index
+    f = open("licenses_retrieved.json")
+    licenses_retrieved = json.load(f)
+    for i in licenses_retrieved:
+        for j in licenses_retrieved_at_the_file_level:
+            for k in licenses_retrieved_at_the_file_level[j]:
+                if "packageName" in licenses_retrieved_at_the_file_level[j][k]:
+                    #print("Hello world! line 153")
+                    if licenses_retrieved[i]["packageName"] == licenses_retrieved_at_the_file_level[j][k]["packageName"]:
+
+                        #print("Hello world! line 156")
+
+                        if "PyPILicenseSPDX" in licenses_retrieved[i]:
+                            if licenses_retrieved[i]["PyPILicenseSPDX"] != licenses_retrieved_at_the_file_level[j][k]["spdx_license_key_1"]:
+                                ReportLicensesPackageComparedWithFile[z] = {}
+                                ReportLicensesPackageComparedWithFile[z]["packageName"] = licenses_retrieved[i]["packageName"]
+                                ReportLicensesPackageComparedWithFile[z]["PyPILicenseSPDX"] = licenses_retrieved[i]["PyPILicenseSPDX"]
+                                ReportLicensesPackageComparedWithFile[z]["filePath"] = licenses_retrieved_at_the_file_level[j][k]["path"]
+                                # this is surely different
+                                ReportLicensesPackageComparedWithFile[z]["ScancodeLicense"] = \
+                                licenses_retrieved_at_the_file_level[j][k]["spdx_license_key_1"]
+                                ReportLicensesPackageComparedWithFile[z]["MessageReport"] = "Scancode detected a license which is not the one declared at the package level"
+                                z += 1
+                        if "GitHubLicenseSPDX" in licenses_retrieved[i]:
+                            if licenses_retrieved[i]["GitHubLicenseSPDX"] != licenses_retrieved_at_the_file_level[j][k]["spdx_license_key_1"]:
+                                ReportLicensesPackageComparedWithFile[z] = {}
+                                ReportLicensesPackageComparedWithFile[z]["packageName"] = licenses_retrieved[i]["packageName"]
+                                ReportLicensesPackageComparedWithFile[z]["PyPILicenseSPDX"] = licenses_retrieved[i]["PyPILicenseSPDX"]
+                                ReportLicensesPackageComparedWithFile[z]["filePath"] = licenses_retrieved_at_the_file_level[j][k]["path"]
+                                # this is surely different
+                                ReportLicensesPackageComparedWithFile[z]["ScancodeLicense"] = \
+                                licenses_retrieved_at_the_file_level[j][k]["spdx_license_key_1"]
+                                ReportLicensesPackageComparedWithFile[z]["MessageReport"] = "Scancode detected a license which is not the one declared at the package level"
+                                z += 1
+    with open('ReportLicensesPackageComparedWithFile.json', 'w') as convert_file:
+        json.dump(ReportLicensesPackageComparedWithFile, convert_file, indent=4)
+
+    return ReportLicensesPackageComparedWithFile
+

--- a/src/fasten/licensesApplicationToTheStitchedCallGraph.py
+++ b/src/fasten/licensesApplicationToTheStitchedCallGraph.py
@@ -154,33 +154,27 @@ def CompareLicensesAtThePackageLevelWithTheFileLevel(licenses_retrieved_data, li
         for j in licenses_retrieved_at_the_file_level:
             for k in licenses_retrieved_at_the_file_level[j]:
                 if "packageName" in licenses_retrieved_at_the_file_level[j][k]:
-                    #print("Hello world! line 153")
                     if licenses_retrieved[i]["packageName"] == licenses_retrieved_at_the_file_level[j][k]["packageName"]:
-
-                        #print("Hello world! line 156")
-
                         if "PyPILicenseSPDX" in licenses_retrieved[i]:
-                            if licenses_retrieved[i]["PyPILicenseSPDX"] != licenses_retrieved_at_the_file_level[j][k]["spdx_license_key_1"]:
-                                ReportLicensesPackageComparedWithFile[z] = {}
-                                ReportLicensesPackageComparedWithFile[z]["packageName"] = licenses_retrieved[i]["packageName"]
-                                ReportLicensesPackageComparedWithFile[z]["PyPILicenseSPDX"] = licenses_retrieved[i]["PyPILicenseSPDX"]
-                                ReportLicensesPackageComparedWithFile[z]["filePath"] = licenses_retrieved_at_the_file_level[j][k]["path"]
-                                # this is surely different
-                                ReportLicensesPackageComparedWithFile[z]["ScancodeLicense"] = \
-                                licenses_retrieved_at_the_file_level[j][k]["spdx_license_key_1"]
-                                ReportLicensesPackageComparedWithFile[z]["MessageReport"] = "Scancode detected a license which is not the one declared at the package level"
-                                z += 1
+                            for license in licenses_retrieved_at_the_file_level[j][k]["spdx_license_key"]:
+                                if licenses_retrieved[i]["PyPILicenseSPDX"] != license:
+                                    ReportLicensesPackageComparedWithFile[z] = {}
+                                    ReportLicensesPackageComparedWithFile[z]["packageName"] = licenses_retrieved[i]["packageName"]
+                                    ReportLicensesPackageComparedWithFile[z]["PyPILicenseSPDX"] = licenses_retrieved[i]["PyPILicenseSPDX"]
+                                    ReportLicensesPackageComparedWithFile[z]["filePath"] = licenses_retrieved_at_the_file_level[j][k]["path"]
+                                    ReportLicensesPackageComparedWithFile[z]["ScancodeLicense"] = license
+                                    ReportLicensesPackageComparedWithFile[z]["MessageReport"] = "Scancode detected a license which is not the one declared at the package level"
+                                    z += 1
                         if "GitHubLicenseSPDX" in licenses_retrieved[i]:
-                            if licenses_retrieved[i]["GitHubLicenseSPDX"] != licenses_retrieved_at_the_file_level[j][k]["spdx_license_key_1"]:
-                                ReportLicensesPackageComparedWithFile[z] = {}
-                                ReportLicensesPackageComparedWithFile[z]["packageName"] = licenses_retrieved[i]["packageName"]
-                                ReportLicensesPackageComparedWithFile[z]["PyPILicenseSPDX"] = licenses_retrieved[i]["PyPILicenseSPDX"]
-                                ReportLicensesPackageComparedWithFile[z]["filePath"] = licenses_retrieved_at_the_file_level[j][k]["path"]
-                                # this is surely different
-                                ReportLicensesPackageComparedWithFile[z]["ScancodeLicense"] = \
-                                licenses_retrieved_at_the_file_level[j][k]["spdx_license_key_1"]
-                                ReportLicensesPackageComparedWithFile[z]["MessageReport"] = "Scancode detected a license which is not the one declared at the package level"
-                                z += 1
+                            for license in licenses_retrieved_at_the_file_level[j][k]["spdx_license_key"]:
+                                if licenses_retrieved[i]["GitHubLicenseSPDX"] != license:
+                                    ReportLicensesPackageComparedWithFile[z] = {}
+                                    ReportLicensesPackageComparedWithFile[z]["packageName"] = licenses_retrieved[i]["packageName"]
+                                    ReportLicensesPackageComparedWithFile[z]["PyPILicenseSPDX"] = licenses_retrieved[i]["PyPILicenseSPDX"]
+                                    ReportLicensesPackageComparedWithFile[z]["filePath"] = licenses_retrieved_at_the_file_level[j][k]["path"]
+                                    ReportLicensesPackageComparedWithFile[z]["ScancodeLicense"] = license
+                                    ReportLicensesPackageComparedWithFile[z]["MessageReport"] = "Scancode detected a license which is not the one declared at the package level"
+                                    z += 1
     with open('ReportLicensesPackageComparedWithFile.json', 'w') as convert_file:
         json.dump(ReportLicensesPackageComparedWithFile, convert_file, indent=4)
 

--- a/src/fasten/licensesApplicationToTheStitchedCallGraph.py
+++ b/src/fasten/licensesApplicationToTheStitchedCallGraph.py
@@ -1,8 +1,8 @@
 import json
 import re
 
-def licensesApplicationToTheStitchedCallGraph(stitched_call_graph, licenses_retrieved_from_fasten_at_files_level, licenses_retrieved_at_the_package_level ):
-    callablesReportedForLicenseViolation = {}
+def licensesAtThePackageLevelApplicationToTheStitchedCallGraph(stitched_call_graph, licenses_retrieved_at_the_package_level ):
+
     callablesEnrichedWithLicenseInformation = {}
     f = open(stitched_call_graph)
     data = json.load(f)
@@ -10,11 +10,12 @@ def licensesApplicationToTheStitchedCallGraph(stitched_call_graph, licenses_retr
 
     print(licenses_retrieved_at_the_package_level)
 
+    # create a list of package names, used to loop over each callable
     for j in licenses_retrieved_at_the_package_level:
         LicensePackagesList.append(licenses_retrieved_at_the_package_level[j]["packageName"])
 
     for i in data["nodes"]:
-        callablesEnrichedWithLicenseInformation[i] = {}
+
         for element in LicensePackagesList:
             # look for package name inside of the URI
             URI = data["nodes"][i]["URI"]
@@ -22,19 +23,68 @@ def licensesApplicationToTheStitchedCallGraph(stitched_call_graph, licenses_retr
             packageNameMatch = re.findall("(?<=\!)(.*?)(?=\$)", URI)
             # match the package name in the URI, using ! and $ as a delimiter
             if packageNameMatch[0] == element:
-                callablesEnrichedWithLicenseInformation[i]["URI"] = URI
-                print(element + " found in " + str(URI))
+                #print(element + " found in " + str(URI))
                 for j in licenses_retrieved_at_the_package_level:
                     # look for package name inside of the licenses package level
                     if element in licenses_retrieved_at_the_package_level[j]["packageName"]:
                         if "PyPILicenseSPDX" in licenses_retrieved_at_the_package_level[j]:
+                            callablesEnrichedWithLicenseInformation[i] = {}
+                            callablesEnrichedWithLicenseInformation[i]["URI"] = URI
                             callablesEnrichedWithLicenseInformation[i]["PyPILicenseSPDX_at_package_level"] = licenses_retrieved_at_the_package_level[j]["PyPILicenseSPDX"]
-                            print(callablesEnrichedWithLicenseInformation[i]["PyPILicenseSPDX_at_package_level"])
+                            #print(callablesEnrichedWithLicenseInformation[i]["PyPILicenseSPDX_at_package_level"])
                         else:
                             if "GitHubLicenseSPDX" in licenses_retrieved_at_the_package_level[j]:
+                                callablesEnrichedWithLicenseInformation[i] = {}
+                                callablesEnrichedWithLicenseInformation[i]["URI"] = URI
                                 callablesEnrichedWithLicenseInformation[i]["GitHubLicenseSPDX_at_package_level"] = licenses_retrieved_at_the_package_level[j]["GitHubLicenseSPDX"]
-                                print(callablesEnrichedWithLicenseInformation[i]["GitHubLicenseSPDX_at_package_level"])
-    #print("callablesEnrichedWithLicenseInformation:")
-    #print(callablesEnrichedWithLicenseInformation)
+                                #print(callablesEnrichedWithLicenseInformation[i]["GitHubLicenseSPDX_at_package_level"])
+
+    with open('callablesEnrichedWithLicenseInformation.json', 'w') as convert_file:
+        json.dump(callablesEnrichedWithLicenseInformation, convert_file, indent=4)
 
     return callablesEnrichedWithLicenseInformation
+
+def licensesAtTheFileLevelApplicationToTheStitchedCallGraph(licenses_retrieved_at_the_file_level, callablesEnrichedWithLicenseInformation, stitched_call_graph):
+    callablesEnrichedWithLicenseAtFileLevel = {}
+    # loading the stitch call graph
+    f = open(stitched_call_graph)
+    data = json.load(f)
+
+    # list of packages with licenses declared at the file level
+    FileLicensePackagesList = []
+    for j in licenses_retrieved_at_the_file_level:
+        for i in licenses_retrieved_at_the_file_level[j]:
+            if "packageName" in licenses_retrieved_at_the_file_level[j][i]:
+                if str(licenses_retrieved_at_the_file_level[j][i]["packageName"]) not in FileLicensePackagesList:
+                    FileLicensePackagesList.append(licenses_retrieved_at_the_file_level[j][i]["packageName"])
+    print("FileLicensePackagesList")
+    print(FileLicensePackagesList)
+
+    for i in data["nodes"]:
+
+        # look for package name inside of the URI
+        URI = data["nodes"][i]["URI"]
+        # extract the package name from the URI
+        packageNameMatch = re.findall("(?<=\!)(.*?)(?=\$)", URI)
+
+        for j in licenses_retrieved_at_the_file_level:
+            for k in licenses_retrieved_at_the_file_level[j]:
+                if "packageName" in licenses_retrieved_at_the_file_level[j][k]:
+                    print(licenses_retrieved_at_the_file_level[j][k]["packageName"])
+                    # match the package name in the URI, using ! and $ as a delimiter - against the licenses at file level list
+                    if packageNameMatch[0] == licenses_retrieved_at_the_file_level[j][k]["packageName"]:
+                        # path conversion into fasten cg format
+                        path = licenses_retrieved_at_the_file_level[j][k]["path"]
+                        path = path.replace("/",".")
+                        path = path.replace(".py","")
+                        print(path)
+                        if path in URI:
+                            callablesEnrichedWithLicenseAtFileLevel[i] = {}
+                            callablesEnrichedWithLicenseAtFileLevel[i]["URI"] = URI
+                            # here should go a check for all the keys with spdx_license_key_
+                            callablesEnrichedWithLicenseAtFileLevel[i]["SPDX_license_at_the_file_level"] = \
+                            licenses_retrieved_at_the_file_level[j][k]["spdx_license_key_1"]
+    with open('callablesEnrichedWithLicenseAtFileLevel.json', 'w') as convert_file:
+        json.dump(callablesEnrichedWithLicenseAtFileLevel, convert_file, indent=4)
+
+    return callablesEnrichedWithLicenseAtFileLevel

--- a/src/fasten/requestFastenKnownAndUnknownLists.py
+++ b/src/fasten/requestFastenKnownAndUnknownLists.py
@@ -1,0 +1,55 @@
+# Send package name and version to FASTEN and receive a Call Graph or metadata information for it.
+
+import json
+import time
+import requests
+
+class RequestFastenKnownAndUnknownLists:
+
+    @staticmethod
+    def requestFastenKnownAndUnknownLists(args, pkgs, url, path):
+
+        pkgs = json.loads(pkgs)
+        metadata_JSON_File_Locations = [] # Call Graphs and metadata file location
+        known_pkg_metadata = {}
+        unknown_pkg_metadata = {}
+        connectivity_issues = {}
+
+        for package in pkgs:
+
+            URL = url + "packages/" + package + "/" + pkgs[package] + "/" + path
+            print(URL)
+            try:
+                response = requests.get(url=URL) # get Call Graph or metadata for specified package
+
+                if response.status_code == 200:
+
+                    metadata_JSON = response.json() # save in JSON format
+                    with open(args.fasten_data + package + "." + path + ".json", "w") as f:
+                        f.write(json.dumps(metadata_JSON)) # save Call Graph or metadata in a file
+
+                    print(type(metadata_JSON))
+                    #look for license
+
+                    metadata_JSON_File_Locations.append(args.fasten_data + package + "." + path + ".json") # append Call Graph or metadata file location to a list
+
+                    print(package + ":" + pkgs[package] + ": " + path + " received.")
+                    known_pkg_metadata[package] = pkgs[package]
+
+                elif response.status_code == 404:
+                    print(package + ":" + pkgs[package] + ": " + path + " not available!")
+                    unknown_pkg_metadata[package] = pkgs[package]
+                else:
+                    print("Querying " + package + ":" + pkgs[package] + ": " + path + " something went wrong.")
+                    print(response.status_code)
+                    connectivity_issues[package] = pkgs[package]
+
+            except requests.exceptions.ReadTimeout:
+                print('Connection timeout: ReadTimeout')
+            except requests.exceptions.ConnectTimeout:
+                print('Connection timeout: ConnectTimeout')
+            except requests.exceptions.ConnectionError:
+                print('Connection timeout: ConnectError')
+                time.sleep(30)
+
+        return metadata_JSON_File_Locations, known_pkg_metadata, unknown_pkg_metadata, connectivity_issues

--- a/src/fasten/requestFastenKnownAndUnknownLists.py
+++ b/src/fasten/requestFastenKnownAndUnknownLists.py
@@ -18,7 +18,7 @@ class RequestFastenKnownAndUnknownLists:
         for package in pkgs:
 
             URL = url + "packages/" + package + "/" + pkgs[package] + "/" + path
-            print(URL)
+            #print(URL)
             try:
                 response = requests.get(url=URL) # get Call Graph or metadata for specified package
 
@@ -28,8 +28,6 @@ class RequestFastenKnownAndUnknownLists:
                     with open(args.fasten_data + package + "." + path + ".json", "w") as f:
                         f.write(json.dumps(metadata_JSON)) # save Call Graph or metadata in a file
 
-                    print(type(metadata_JSON))
-                    #look for license
 
                     metadata_JSON_File_Locations.append(args.fasten_data + package + "." + path + ".json") # append Call Graph or metadata file location to a list
 

--- a/src/fasten/requestFastenLicenseInformation.py
+++ b/src/fasten/requestFastenLicenseInformation.py
@@ -1,9 +1,13 @@
-# Send package name and version to FASTEN and receive a Call Graph or metadata information for it.
-
 import json
 import time
 import requests
 from gitHubAndPyPIParsingUtils import IsAnSPDX, ConvertToSPDX
+
+'''
+* SPDX-FileCopyrightText: 2022 Michele Scarlato <michele.scarlato@endocode.com>
+*
+* SPDX-License-Identifier: Apache-2.0
+'''
 
 class RequestFastenLicenseInformation:
 

--- a/src/fasten/requestFastenLicenseInformation.py
+++ b/src/fasten/requestFastenLicenseInformation.py
@@ -1,0 +1,124 @@
+# Send package name and version to FASTEN and receive a Call Graph or metadata information for it.
+
+import json
+import time
+import requests
+from gitHubAndPyPIParsingUtils import IsAnSPDX, ConvertToSPDX
+
+class RequestFastenLicenseInformation:
+
+    @staticmethod
+    def requestFastenLicenseInformation(args, pkgs, url, LCVurl):
+
+        print("Receive metadata from FASTEN:")
+        pkgs = json.loads(pkgs)
+        metadata_JSON_File_Locations = [] # Call Graphs and metadata file location
+        known_pkg_metadata = {}
+        unknown_pkg_metadata = {}
+        connectivity_issues = {}
+        licenses = {}
+        i = 0
+
+        for package in pkgs:
+            packageName = package
+            packageVersion = pkgs[package]
+
+            URL = url + "packages/" + package + "/" + pkgs[package] + "/metadata"
+            #print(URL)
+            try:
+                response = requests.get(url=URL) # get Call Graph or metadata for specified package
+
+                if response.status_code == 200:
+
+                    metadata_JSON = response.json() # save in JSON format
+                    with open(args.fasten_data + package + ".metadata.json", "w") as f:
+                        f.write(json.dumps(metadata_JSON)) # save metadata in a file
+
+                    #look for licenses
+                    if "licenses" in metadata_JSON["metadata"]:
+                        licensesFasten = metadata_JSON["metadata"]["licenses"]
+                        if len(licensesFasten) > 0:
+                            print("License available for " + package + " from FASTEN server. ")
+                            #print(licensesFasten)
+                            licenses[i] = {}
+                            for licenseListElement in licensesFasten:
+                                #print(element)
+                                if licenseListElement["source"] == "GITHUB":
+                                    IsSPDX = IsAnSPDX(str(licenseListElement["name"]), LCVurl)
+                                    if IsSPDX is not True:
+                                        License = ConvertToSPDX(str(licenseListElement["name"]), LCVurl)
+                                        if IsAnSPDX(License, LCVurl):
+                                            LicenseSPDX = License
+                                        else:
+                                            licenses[i]['packageName'] = packageName
+                                            licenses[i]['packageVersion'] = packageVersion
+                                            licenses[i]['GitHubLicense'] = str(licenseListElement["name"])
+                                            pass
+
+                                        if "LicenseSPDX" in locals():
+                                            # add to licenses the license under the GitHubSPDX key
+                                            licenses[i]['packageName'] = packageName
+                                            licenses[i]['packageVersion'] = packageVersion
+                                            licenses[i]['GitHubLicenseSPDX'] = LicenseSPDX
+                                            pass
+                                    else:
+                                        License = str(licenseListElement["name"])
+                                        licenses[i]['packageName'] = packageName
+                                        licenses[i]['packageVersion'] = packageVersion
+                                        licenses[i]['GitHubLicenseSPDX'] = License
+                                        pass
+                                        # add to licenses the license under the GitHubSPDX key
+                                if licenseListElement["source"] == "PYPI":
+                                    IsSPDX = IsAnSPDX(str(licenseListElement["name"]), LCVurl)
+                                    if IsSPDX is not True:
+                                        License = ConvertToSPDX(str(licenseListElement["name"]), LCVurl)
+                                        if IsAnSPDX(License, LCVurl):
+                                            LicenseSPDX = License
+                                        else:
+                                            licenses[i]['packageName'] = packageName
+                                            licenses[i]['packageVersion'] = packageVersion
+                                            licenses[i]['PyPI_not_SPDX'] = str(licenseListElement["name"])
+                                            pass
+
+                                    if "LicenseSPDX" in locals():
+                                        # add to licenses the license under the GitHubSPDX key
+                                        licenses[i]['packageName'] = packageName
+                                        licenses[i]['packageVersion'] = packageVersion
+                                        licenses[i]['PyPILicenseSPDX'] = LicenseSPDX
+                                        pass
+                                    else:
+                                        License = str(licenseListElement["name"])
+                                        licenses[i]['packageName'] = packageName
+                                        licenses[i]['packageVersion'] = packageVersion
+                                        licenses[i]['PyPILicenseSPDX'] = License
+                                        pass
+                                known_pkg_metadata[package] = pkgs[package]
+                                i += 1
+                            i += 1
+                        else:
+                            print("Empty licenses for " + package + " from FASTEN server. ")
+                    else:
+                        print("License unavailable for " + package + " from FASTEN server. ")
+
+                    metadata_JSON_File_Locations.append(args.fasten_data + package + ".metadata.json") # append Call Graph or metadata file location to a list
+
+                    print(package + ":" + pkgs[package] + ": metadata received.")
+                    known_pkg_metadata[package] = pkgs[package]
+
+                elif response.status_code == 404:
+                    print(package + ":" + pkgs[package] + ": metadata not available!")
+                    unknown_pkg_metadata[package] = pkgs[package]
+                else:
+                    print("Querying " + package + ":" + pkgs[package] + ": metadata something went wrong.")
+                    print(response.status_code)
+                    connectivity_issues[package] = pkgs[package]
+
+            except requests.exceptions.ReadTimeout:
+                print('Connection timeout: ReadTimeout')
+            except requests.exceptions.ConnectTimeout:
+                print('Connection timeout: ConnectTimeout')
+            except requests.exceptions.ConnectionError:
+                print('Connection timeout: ConnectError')
+                time.sleep(30)
+
+        return metadata_JSON_File_Locations, known_pkg_metadata, unknown_pkg_metadata, connectivity_issues, licenses, i

--- a/src/fasten/retrieveLicenseInformation.py
+++ b/src/fasten/retrieveLicenseInformation.py
@@ -1,0 +1,25 @@
+from requestFastenLicenseInformation import RequestFastenLicenseInformation
+from retrieveLocallyLicensesInformation import ReceiveLocallyLicensesInformation
+from retrieveLicensesAtTheFileLevel import RetrieveLicensesAtTheFileLevel
+
+
+def retrieveLicenseInformation(args, all_pkgs, url, LCVurl):
+
+    # request to fasten license information at the package level.
+    metadata_JSON_File_Locations, known_pkgs_metadata, unknown_pkgs_metadata, connectivity_issues, \
+licenses_retrieved_from_fasten, index = RequestFastenLicenseInformation.requestFastenLicenseInformation(args, all_pkgs, url, LCVurl)
+    print("license retrieved from fasten:")
+    print(licenses_retrieved_from_fasten)
+
+    # retrieve license information at the package level, querying PyPI and GitHub.
+    licenses_retrieved_locally = ReceiveLocallyLicensesInformation.receiveLocallyLicensesInformation(unknown_pkgs_metadata, LCVurl, index)
+    print("license retrieved locally:")
+    print(licenses_retrieved_locally)
+
+
+    # request to fasten license information at the file level.
+    metadata_JSON_File_Locations, known_files_metadata, unknown_files_metadata, connectivity_issues, file_licenses = RetrieveLicensesAtTheFileLevel.retrieveLicensesAtTheFileLevel(args, all_pkgs, url)
+    print("license retrieved from fasten at the file level:")
+    print(file_licenses)
+
+    return licenses_retrieved_from_fasten, licenses_retrieved_locally, file_licenses

--- a/src/fasten/retrieveLicenseInformation.py
+++ b/src/fasten/retrieveLicenseInformation.py
@@ -2,24 +2,23 @@ from requestFastenLicenseInformation import RequestFastenLicenseInformation
 from retrieveLocallyLicensesInformation import ReceiveLocallyLicensesInformation
 from retrieveLicensesAtTheFileLevel import RetrieveLicensesAtTheFileLevel
 
+'''
+* SPDX-FileCopyrightText: 2022 Michele Scarlato <michele.scarlato@endocode.com>
+*
+* SPDX-License-Identifier: Apache-2.0
+'''
 
 def retrieveLicenseInformation(args, all_pkgs, url, LCVurl):
 
     # request to fasten license information at the package level.
     metadata_JSON_File_Locations, known_pkgs_metadata, unknown_pkgs_metadata, connectivity_issues, \
 licenses_retrieved_from_fasten, index = RequestFastenLicenseInformation.requestFastenLicenseInformation(args, all_pkgs, url, LCVurl)
-    # print("license retrieved from fasten:")
-    # print(licenses_retrieved_from_fasten)
 
     # retrieve license information at the package level, querying PyPI and GitHub.
     licenses_retrieved_locally = ReceiveLocallyLicensesInformation.receiveLocallyLicensesInformation(unknown_pkgs_metadata, LCVurl, index)
-    # print("license retrieved locally:")
-    # print(licenses_retrieved_locally)
 
 
     # request to fasten license information at the file level.
     metadata_JSON_File_Locations, known_files_metadata, unknown_files_metadata, connectivity_issues, file_licenses = RetrieveLicensesAtTheFileLevel.retrieveLicensesAtTheFileLevel(args, all_pkgs, url)
-    # print("license retrieved from fasten at the file level:")
-    # print(file_licenses)
 
     return licenses_retrieved_from_fasten, licenses_retrieved_locally, file_licenses

--- a/src/fasten/retrieveLicenseInformation.py
+++ b/src/fasten/retrieveLicenseInformation.py
@@ -8,18 +8,18 @@ def retrieveLicenseInformation(args, all_pkgs, url, LCVurl):
     # request to fasten license information at the package level.
     metadata_JSON_File_Locations, known_pkgs_metadata, unknown_pkgs_metadata, connectivity_issues, \
 licenses_retrieved_from_fasten, index = RequestFastenLicenseInformation.requestFastenLicenseInformation(args, all_pkgs, url, LCVurl)
-    print("license retrieved from fasten:")
-    print(licenses_retrieved_from_fasten)
+    #print("license retrieved from fasten:")
+    #print(licenses_retrieved_from_fasten)
 
     # retrieve license information at the package level, querying PyPI and GitHub.
     licenses_retrieved_locally = ReceiveLocallyLicensesInformation.receiveLocallyLicensesInformation(unknown_pkgs_metadata, LCVurl, index)
-    print("license retrieved locally:")
-    print(licenses_retrieved_locally)
+    #print("license retrieved locally:")
+    #print(licenses_retrieved_locally)
 
 
     # request to fasten license information at the file level.
     metadata_JSON_File_Locations, known_files_metadata, unknown_files_metadata, connectivity_issues, file_licenses = RetrieveLicensesAtTheFileLevel.retrieveLicensesAtTheFileLevel(args, all_pkgs, url)
-    print("license retrieved from fasten at the file level:")
-    print(file_licenses)
+    #print("license retrieved from fasten at the file level:")
+    #print(file_licenses)
 
     return licenses_retrieved_from_fasten, licenses_retrieved_locally, file_licenses

--- a/src/fasten/retrieveLicenseInformation.py
+++ b/src/fasten/retrieveLicenseInformation.py
@@ -8,18 +8,18 @@ def retrieveLicenseInformation(args, all_pkgs, url, LCVurl):
     # request to fasten license information at the package level.
     metadata_JSON_File_Locations, known_pkgs_metadata, unknown_pkgs_metadata, connectivity_issues, \
 licenses_retrieved_from_fasten, index = RequestFastenLicenseInformation.requestFastenLicenseInformation(args, all_pkgs, url, LCVurl)
-    #print("license retrieved from fasten:")
-    #print(licenses_retrieved_from_fasten)
+    # print("license retrieved from fasten:")
+    # print(licenses_retrieved_from_fasten)
 
     # retrieve license information at the package level, querying PyPI and GitHub.
     licenses_retrieved_locally = ReceiveLocallyLicensesInformation.receiveLocallyLicensesInformation(unknown_pkgs_metadata, LCVurl, index)
-    #print("license retrieved locally:")
-    #print(licenses_retrieved_locally)
+    # print("license retrieved locally:")
+    # print(licenses_retrieved_locally)
 
 
     # request to fasten license information at the file level.
     metadata_JSON_File_Locations, known_files_metadata, unknown_files_metadata, connectivity_issues, file_licenses = RetrieveLicensesAtTheFileLevel.retrieveLicensesAtTheFileLevel(args, all_pkgs, url)
-    #print("license retrieved from fasten at the file level:")
-    #print(file_licenses)
+    # print("license retrieved from fasten at the file level:")
+    # print(file_licenses)
 
     return licenses_retrieved_from_fasten, licenses_retrieved_locally, file_licenses

--- a/src/fasten/retrieveLicensesAtTheFileLevel.py
+++ b/src/fasten/retrieveLicensesAtTheFileLevel.py
@@ -14,7 +14,7 @@ class RetrieveLicensesAtTheFileLevel:
         unknown_files_metadata = {}
         files_connectivity_issues = {}
         file_licenses = {}
-        i = 0
+
 
         for package in pkgs:
             packageName = package
@@ -34,12 +34,15 @@ class RetrieveLicensesAtTheFileLevel:
                     # print(type(metadata_JSON))
                     # look for licenses
                     for l in metadata_JSON:
+                        i = 0
+                        print(l["path"])
+                        filePath = l["path"]
                         print(l["metadata"])
                         if l["metadata"] is not None:
                             if "licenses" in l["metadata"]:
                                 licensesFasten = l["metadata"]["licenses"]
                                 if len(licensesFasten) > 0:
-                                    print("License available for " + package + " from FASTEN server. ")
+                                    print("License available for file: " + filePath + " " + package + " from FASTEN server.")
                                     print(licensesFasten)
 
                                     for element in licensesFasten:
@@ -48,6 +51,7 @@ class RetrieveLicensesAtTheFileLevel:
                                             print("element[spdx_license_key]:")
                                             print(element["spdx_license_key"])
                                             print("PackageName:" + packageName)
+                                            print("File path:" + filePath)
                                             print("file index:" + str(i))
                                             if i == 0:
                                                 file_licenses[packageName][i] = {}
@@ -57,10 +61,10 @@ class RetrieveLicensesAtTheFileLevel:
                                                 file_licenses[packageName][i]["spdx_license_key"] = element[
                                                     "spdx_license_key"]
                                                 i += 1
+                                            # stores only 1 instance of the same license for the same path
                                             if i > 0:
                                                 if (file_licenses[packageName][i - 1]["path"] == l["path"]):
-                                                    if (file_licenses[packageName][i - 1]["spdx_license_key"] != element[
-                                                        "spdx_license_key"]):
+                                                    if (file_licenses[packageName][i - 1]["spdx_license_key"] != element["spdx_license_key"]):
                                                         file_licenses[packageName][i] = {}
                                                         file_licenses[packageName][i]["packageName"] = packageName
                                                         file_licenses[packageName][i]["packageVersion"] = packageVersion

--- a/src/fasten/retrieveLicensesAtTheFileLevel.py
+++ b/src/fasten/retrieveLicensesAtTheFileLevel.py
@@ -1,8 +1,13 @@
 import json
 import time
 import requests
-from gitHubAndPyPIParsingUtils import IsAnSPDX, ConvertToSPDX
 
+
+'''
+* SPDX-FileCopyrightText: 2022 Michele Scarlato <michele.scarlato@endocode.com>
+*
+* SPDX-License-Identifier: Apache-2.0
+'''
 
 class RetrieveLicensesAtTheFileLevel:
     @staticmethod
@@ -20,7 +25,7 @@ class RetrieveLicensesAtTheFileLevel:
             packageName = package
             packageVersion = pkgs[package]
             URL = url + "packages/" + package + "/" + pkgs[package] + "/files"
-            print(URL)
+            #print(URL)
             try:
                 response = requests.get(url=URL)  # get Call Graph or metadata for specified package
 
@@ -42,7 +47,7 @@ class RetrieveLicensesAtTheFileLevel:
                             if "licenses" in file["metadata"]:
                                 licensesFasten = file["metadata"]["licenses"]
                                 if len(licensesFasten) > 0:
-                                    print("License available for file: " + filePath + " - " + package + " from FASTEN server.")
+                                    #print("License available for file: " + filePath + " - " + package + " from FASTEN server.")
                                     file_licenses[packageName][filePath] = {}
                                     file_licenses[packageName][filePath]["spdx_license_key"] = []
                                     for license in licensesFasten:

--- a/src/fasten/retrieveLicensesAtTheFileLevel.py
+++ b/src/fasten/retrieveLicensesAtTheFileLevel.py
@@ -4,69 +4,52 @@ import requests
 from gitHubAndPyPIParsingUtils import IsAnSPDX, ConvertToSPDX
 
 
-def retrieveLicensesAtTheFileLevel(args, pkgs, url):
-    print("Receive metadata from FASTEN:")
-    pkgs = json.loads(pkgs)
-    metadata_JSON_File_Locations = []  # Call Graphs and metadata file location
-    known_files_metadata = {}
-    unknown_files_metadata = {}
-    files_connectivity_issues = {}
-    file_licenses = {}
-    i = 0
+class RetrieveLicensesAtTheFileLevel:
+    @staticmethod
+    def retrieveLicensesAtTheFileLevel(args, pkgs, url):
+        print("Receive metadata from FASTEN:")
+        pkgs = json.loads(pkgs)
+        metadata_JSON_File_Locations = []  # Call Graphs and metadata file location
+        known_files_metadata = {}
+        unknown_files_metadata = {}
+        files_connectivity_issues = {}
+        file_licenses = {}
+        i = 0
 
-    for package in pkgs:
-        packageName = package
-        packageVersion = pkgs[package]
-        file_licenses[packageName] = {}
-        URL = url + "packages/" + package + "/" + pkgs[package] + "/files"
-        print(URL)
-        try:
-            response = requests.get(url=URL)  # get Call Graph or metadata for specified package
+        for package in pkgs:
+            packageName = package
+            packageVersion = pkgs[package]
+            file_licenses[packageName] = {}
+            URL = url + "packages/" + package + "/" + pkgs[package] + "/files"
+            print(URL)
+            try:
+                response = requests.get(url=URL)  # get Call Graph or metadata for specified package
 
-            if response.status_code == 200:
+                if response.status_code == 200:
 
-                metadata_JSON = response.json()  # save in JSON format
-                with open(args.fasten_data + package + ".files.json", "w") as f:
-                    f.write(json.dumps(metadata_JSON))  # save Call Graph or metadata in a file
+                    metadata_JSON = response.json()  # save in JSON format
+                    with open(args.fasten_data + package + ".files.json", "w") as f:
+                        f.write(json.dumps(metadata_JSON))  # save Call Graph or metadata in a file
 
-                # print(type(metadata_JSON))
-                # look for licenses
-                for l in metadata_JSON:
-                    print(l["metadata"])
-                    if l["metadata"] is not None:
-                        if "licenses" in l["metadata"]:
-                            licensesFasten = l["metadata"]["licenses"]
-                            if len(licensesFasten) > 0:
-                                print("License available for " + package + " from FASTEN server. ")
-                                print(licensesFasten)
+                    # print(type(metadata_JSON))
+                    # look for licenses
+                    for l in metadata_JSON:
+                        print(l["metadata"])
+                        if l["metadata"] is not None:
+                            if "licenses" in l["metadata"]:
+                                licensesFasten = l["metadata"]["licenses"]
+                                if len(licensesFasten) > 0:
+                                    print("License available for " + package + " from FASTEN server. ")
+                                    print(licensesFasten)
 
-                                for element in licensesFasten:
-                                    print(element)
-                                    if "spdx_license_key" in element:
-                                        print("element[spdx_license_key]:")
-                                        print(element["spdx_license_key"])
-                                        print("PackageName:" + packageName)
-                                        print("file index:" + str(i))
-                                        if i == 0:
-                                            file_licenses[packageName][i] = {}
-                                            file_licenses[packageName][i]["packageName"] = packageName
-                                            file_licenses[packageName][i]["packageVersion"] = packageVersion
-                                            file_licenses[packageName][i]["path"] = l["path"]
-                                            file_licenses[packageName][i]["spdx_license_key"] = element[
-                                                "spdx_license_key"]
-                                            i += 1
-                                        if i > 0:
-                                            if (file_licenses[packageName][i - 1]["path"] == l["path"]):
-                                                if (file_licenses[packageName][i - 1]["spdx_license_key"] != element[
-                                                    "spdx_license_key"]):
-                                                    file_licenses[packageName][i] = {}
-                                                    file_licenses[packageName][i]["packageName"] = packageName
-                                                    file_licenses[packageName][i]["packageVersion"] = packageVersion
-                                                    file_licenses[packageName][i]["path"] = l["path"]
-                                                    file_licenses[packageName][i]["spdx_license_key"] = element[
-                                                        "spdx_license_key"]
-                                                    i += 1
-                                            else:
+                                    for element in licensesFasten:
+                                        print(element)
+                                        if "spdx_license_key" in element:
+                                            print("element[spdx_license_key]:")
+                                            print(element["spdx_license_key"])
+                                            print("PackageName:" + packageName)
+                                            print("file index:" + str(i))
+                                            if i == 0:
                                                 file_licenses[packageName][i] = {}
                                                 file_licenses[packageName][i]["packageName"] = packageName
                                                 file_licenses[packageName][i]["packageVersion"] = packageVersion
@@ -74,29 +57,48 @@ def retrieveLicensesAtTheFileLevel(args, pkgs, url):
                                                 file_licenses[packageName][i]["spdx_license_key"] = element[
                                                     "spdx_license_key"]
                                                 i += 1
-                                known_files_metadata[package] = pkgs[package]
-                    else:
-                        print("License unavailable for " + package + " from FASTEN server. ")
+                                            if i > 0:
+                                                if (file_licenses[packageName][i - 1]["path"] == l["path"]):
+                                                    if (file_licenses[packageName][i - 1]["spdx_license_key"] != element[
+                                                        "spdx_license_key"]):
+                                                        file_licenses[packageName][i] = {}
+                                                        file_licenses[packageName][i]["packageName"] = packageName
+                                                        file_licenses[packageName][i]["packageVersion"] = packageVersion
+                                                        file_licenses[packageName][i]["path"] = l["path"]
+                                                        file_licenses[packageName][i]["spdx_license_key"] = element[
+                                                            "spdx_license_key"]
+                                                        i += 1
+                                                else:
+                                                    file_licenses[packageName][i] = {}
+                                                    file_licenses[packageName][i]["packageName"] = packageName
+                                                    file_licenses[packageName][i]["packageVersion"] = packageVersion
+                                                    file_licenses[packageName][i]["path"] = l["path"]
+                                                    file_licenses[packageName][i]["spdx_license_key"] = element[
+                                                        "spdx_license_key"]
+                                                    i += 1
+                                    known_files_metadata[package] = pkgs[package]
+                        else:
+                            print("License unavailable for " + package + " from FASTEN server. ")
 
-                        metadata_JSON_File_Locations.append(
-                            args.fasten_data + package + ".metadata.json")  # append Call Graph or metadata file location to a list
+                            metadata_JSON_File_Locations.append(
+                                args.fasten_data + package + ".metadata.json")  # append Call Graph or metadata file location to a list
 
-                        print(package + ":" + pkgs[package] + ": metadata received.")
-                        known_files_metadata[package] = pkgs[package]
+                            print(package + ":" + pkgs[package] + ": metadata received.")
+                            known_files_metadata[package] = pkgs[package]
 
-            elif response.status_code == 404:
-                print(package + ":" + pkgs[package] + ": metadata not available!")
-                unknown_files_metadata[package] = pkgs[package]
-            else:
-                print("Querying " + package + ":" + pkgs[package] + ": metadata something went wrong.")
-                print(response.status_code)
-                files_connectivity_issues[package] = pkgs[package]
+                elif response.status_code == 404:
+                    print(package + ":" + pkgs[package] + ": metadata not available!")
+                    unknown_files_metadata[package] = pkgs[package]
+                else:
+                    print("Querying " + package + ":" + pkgs[package] + ": metadata something went wrong.")
+                    print(response.status_code)
+                    files_connectivity_issues[package] = pkgs[package]
 
-        except requests.exceptions.ReadTimeout:
-            print('Connection timeout: ReadTimeout')
-        except requests.exceptions.ConnectTimeout:
-            print('Connection timeout: ConnectTimeout')
-        except requests.exceptions.ConnectionError:
-            print('Connection timeout: ConnectError')
-            time.sleep(30)
-    return metadata_JSON_File_Locations, known_files_metadata, unknown_files_metadata, files_connectivity_issues, file_licenses
+            except requests.exceptions.ReadTimeout:
+                print('Connection timeout: ReadTimeout')
+            except requests.exceptions.ConnectTimeout:
+                print('Connection timeout: ConnectTimeout')
+            except requests.exceptions.ConnectionError:
+                print('Connection timeout: ConnectError')
+                time.sleep(30)
+        return metadata_JSON_File_Locations, known_files_metadata, unknown_files_metadata, files_connectivity_issues, file_licenses

--- a/src/fasten/retrieveLicensesAtTheFileLevel.py
+++ b/src/fasten/retrieveLicensesAtTheFileLevel.py
@@ -1,0 +1,102 @@
+import json
+import time
+import requests
+from gitHubAndPyPIParsingUtils import IsAnSPDX, ConvertToSPDX
+
+
+def retrieveLicensesAtTheFileLevel(args, pkgs, url):
+    print("Receive metadata from FASTEN:")
+    pkgs = json.loads(pkgs)
+    metadata_JSON_File_Locations = []  # Call Graphs and metadata file location
+    known_files_metadata = {}
+    unknown_files_metadata = {}
+    files_connectivity_issues = {}
+    file_licenses = {}
+    i = 0
+
+    for package in pkgs:
+        packageName = package
+        packageVersion = pkgs[package]
+        file_licenses[packageName] = {}
+        URL = url + "packages/" + package + "/" + pkgs[package] + "/files"
+        print(URL)
+        try:
+            response = requests.get(url=URL)  # get Call Graph or metadata for specified package
+
+            if response.status_code == 200:
+
+                metadata_JSON = response.json()  # save in JSON format
+                with open(args.fasten_data + package + ".files.json", "w") as f:
+                    f.write(json.dumps(metadata_JSON))  # save Call Graph or metadata in a file
+
+                # print(type(metadata_JSON))
+                # look for licenses
+                for l in metadata_JSON:
+                    print(l["metadata"])
+                    if l["metadata"] is not None:
+                        if "licenses" in l["metadata"]:
+                            licensesFasten = l["metadata"]["licenses"]
+                            if len(licensesFasten) > 0:
+                                print("License available for " + package + " from FASTEN server. ")
+                                print(licensesFasten)
+
+                                for element in licensesFasten:
+                                    print(element)
+                                    if "spdx_license_key" in element:
+                                        print("element[spdx_license_key]:")
+                                        print(element["spdx_license_key"])
+                                        print("PackageName:" + packageName)
+                                        print("file index:" + str(i))
+                                        if i == 0:
+                                            file_licenses[packageName][i] = {}
+                                            file_licenses[packageName][i]["packageName"] = packageName
+                                            file_licenses[packageName][i]["packageVersion"] = packageVersion
+                                            file_licenses[packageName][i]["path"] = l["path"]
+                                            file_licenses[packageName][i]["spdx_license_key"] = element[
+                                                "spdx_license_key"]
+                                            i += 1
+                                        if i > 0:
+                                            if (file_licenses[packageName][i - 1]["path"] == l["path"]):
+                                                if (file_licenses[packageName][i - 1]["spdx_license_key"] != element[
+                                                    "spdx_license_key"]):
+                                                    file_licenses[packageName][i] = {}
+                                                    file_licenses[packageName][i]["packageName"] = packageName
+                                                    file_licenses[packageName][i]["packageVersion"] = packageVersion
+                                                    file_licenses[packageName][i]["path"] = l["path"]
+                                                    file_licenses[packageName][i]["spdx_license_key"] = element[
+                                                        "spdx_license_key"]
+                                                    i += 1
+                                            else:
+                                                file_licenses[packageName][i] = {}
+                                                file_licenses[packageName][i]["packageName"] = packageName
+                                                file_licenses[packageName][i]["packageVersion"] = packageVersion
+                                                file_licenses[packageName][i]["path"] = l["path"]
+                                                file_licenses[packageName][i]["spdx_license_key"] = element[
+                                                    "spdx_license_key"]
+                                                i += 1
+                                known_files_metadata[package] = pkgs[package]
+                    else:
+                        print("License unavailable for " + package + " from FASTEN server. ")
+
+                        metadata_JSON_File_Locations.append(
+                            args.fasten_data + package + ".metadata.json")  # append Call Graph or metadata file location to a list
+
+                        print(package + ":" + pkgs[package] + ": metadata received.")
+                        known_files_metadata[package] = pkgs[package]
+
+            elif response.status_code == 404:
+                print(package + ":" + pkgs[package] + ": metadata not available!")
+                unknown_files_metadata[package] = pkgs[package]
+            else:
+                print("Querying " + package + ":" + pkgs[package] + ": metadata something went wrong.")
+                print(response.status_code)
+                files_connectivity_issues[package] = pkgs[package]
+
+        except requests.exceptions.ReadTimeout:
+            print('Connection timeout: ReadTimeout')
+        except requests.exceptions.ConnectTimeout:
+            print('Connection timeout: ConnectTimeout')
+        except requests.exceptions.ConnectionError:
+            print('Connection timeout: ConnectError')
+            time.sleep(30)
+    return metadata_JSON_File_Locations, known_files_metadata, unknown_files_metadata, files_connectivity_issues, file_licenses

--- a/src/fasten/retrieveLicensesAtTheFileLevel.py
+++ b/src/fasten/retrieveLicensesAtTheFileLevel.py
@@ -31,56 +31,37 @@ class RetrieveLicensesAtTheFileLevel:
                     with open(args.fasten_data + package + ".files.json", "w") as f:
                         f.write(json.dumps(metadata_JSON))  # save Call Graph or metadata in a file
 
-                    # print(type(metadata_JSON))
                     # look for licenses
-                    for l in metadata_JSON:
-                        i = 0
-                        print(l["path"])
-                        filePath = l["path"]
-                        print(l["metadata"])
-                        if l["metadata"] is not None:
-                            if "licenses" in l["metadata"]:
-                                licensesFasten = l["metadata"]["licenses"]
+                    for file in metadata_JSON:
+                        filePath = file["path"]
+                        file_licenses[packageName][filePath] = {}
+                        if file["metadata"] is not None:
+                            # counter for same licenses for the same file
+                            i = 0
+                            if "licenses" in file["metadata"]:
+                                licensesFasten = file["metadata"]["licenses"]
                                 if len(licensesFasten) > 0:
-                                    print("License available for file: " + filePath + " " + package + " from FASTEN server.")
-                                    print(licensesFasten)
-
-                                    for element in licensesFasten:
-                                        print(element)
-                                        if "spdx_license_key" in element:
-                                            print("element[spdx_license_key]:")
-                                            print(element["spdx_license_key"])
-                                            print("PackageName:" + packageName)
-                                            print("File path:" + filePath)
-                                            print("file index:" + str(i))
+                                    print("License available for file: " + filePath + " - " + package + " from FASTEN server.")
+                                    for license in licensesFasten:
+                                        if "spdx_license_key" in license:
                                             if i == 0:
-                                                file_licenses[packageName][i] = {}
-                                                file_licenses[packageName][i]["packageName"] = packageName
-                                                file_licenses[packageName][i]["packageVersion"] = packageVersion
-                                                file_licenses[packageName][i]["path"] = l["path"]
-                                                file_licenses[packageName][i]["spdx_license_key"] = element[
+                                                file_licenses[packageName][filePath] = {}
+                                                file_licenses[packageName][filePath]["packageName"] = packageName
+                                                file_licenses[packageName][filePath]["packageVersion"] = packageVersion
+                                                file_licenses[packageName][filePath]["path"] = file["path"]
+                                                file_licenses[packageName][filePath]["spdx_license_key_"+ str(i+1)+""] = license[
                                                     "spdx_license_key"]
                                                 i += 1
                                             # stores only 1 instance of the same license for the same path
                                             if i > 0:
-                                                if (file_licenses[packageName][i - 1]["path"] == l["path"]):
-                                                    if (file_licenses[packageName][i - 1]["spdx_license_key"] != element["spdx_license_key"]):
-                                                        file_licenses[packageName][i] = {}
-                                                        file_licenses[packageName][i]["packageName"] = packageName
-                                                        file_licenses[packageName][i]["packageVersion"] = packageVersion
-                                                        file_licenses[packageName][i]["path"] = l["path"]
-                                                        file_licenses[packageName][i]["spdx_license_key"] = element[
+                                                if (file_licenses[packageName][filePath]["path"] == file["path"]):
+                                                    if (file_licenses[packageName][filePath]["spdx_license_key_"+ str(i)+""] != license["spdx_license_key"]):
+
+                                                        file_licenses[packageName][filePath]["spdx_license_key_"+ str(i+1)+""] = license[
                                                             "spdx_license_key"]
                                                         i += 1
-                                                else:
-                                                    file_licenses[packageName][i] = {}
-                                                    file_licenses[packageName][i]["packageName"] = packageName
-                                                    file_licenses[packageName][i]["packageVersion"] = packageVersion
-                                                    file_licenses[packageName][i]["path"] = l["path"]
-                                                    file_licenses[packageName][i]["spdx_license_key"] = element[
-                                                        "spdx_license_key"]
-                                                    i += 1
-                                    known_files_metadata[package] = pkgs[package]
+
+                                known_files_metadata[package] = pkgs[package]
                         else:
                             print("License unavailable for " + package + " from FASTEN server. ")
 
@@ -89,7 +70,6 @@ class RetrieveLicensesAtTheFileLevel:
 
                             print(package + ":" + pkgs[package] + ": metadata received.")
                             known_files_metadata[package] = pkgs[package]
-
                 elif response.status_code == 404:
                     print(package + ":" + pkgs[package] + ": metadata not available!")
                     unknown_files_metadata[package] = pkgs[package]

--- a/src/fasten/retrieveLocallyLicensesInformation.py
+++ b/src/fasten/retrieveLocallyLicensesInformation.py
@@ -1,0 +1,41 @@
+# Send package name and version to FASTEN and receive a Call Graph for it.
+
+from gitHubAndPyPIParsingUtils import *
+
+class ReceiveLocallyLicensesInformation:
+
+    @staticmethod
+    # add the source (e.g. GitHub or PyPI) to the dict!
+    def receiveLocallyLicensesInformation(pkgs, LCVurl, i):
+        print("Retrieval of license information:")
+
+        #licenses = {0: {'packageName' : '', 'PyPILicense' : '', 'GitHubLicense' : ''}}
+        licenses = {}
+        for package in pkgs:
+            licenses[i] = {}
+            packageVersion = pkgs[package]
+            packageName = package
+            licenses[i]['packageName'] = packageName
+            licenses[i]['packageVersion'] = packageVersion
+            PyPILicense, PyPILicenseSPDX, jsonResponse = retrieveLicenseInformationFromPyPI(packageName, packageVersion, LCVurl)
+            if len(PyPILicense) > 0:
+                licenses[i]['PyPILicense'] = PyPILicense
+            if len(PyPILicenseSPDX) > 0:
+                licenses[i]['PyPILicenseSPDX'] = PyPILicenseSPDX
+            #if len(PyPILicense) == 0:
+            GitHubURL = retrieveGitHubUrl(jsonResponse, package)
+            print("GitHub URL Retrieved:")
+            print(GitHubURL)
+            if len(GitHubURL) > 0:
+                GitHubAPIurl = RetrieveGitHubAPIurl(GitHubURL)
+                if len(GitHubURL) > 0:
+                    print(GitHubURL)
+                    GitHubLicense, GitHubLicenseSPDX = RetrieveLicenseFromGitHub(GitHubAPIurl, LCVurl)
+                    if GitHubLicense != "":
+                        if GitHubLicense is not None:
+                            licenses[i]['GitHubLicense'] = GitHubLicense
+                    if GitHubLicenseSPDX != "":
+                        if GitHubLicenseSPDX is not None:
+                            licenses[i]['GitHubLicenseSPDX'] = GitHubLicenseSPDX
+            i+=1
+        return licenses

--- a/src/fasten/retrieveLocallyLicensesInformation.py
+++ b/src/fasten/retrieveLocallyLicensesInformation.py
@@ -1,6 +1,10 @@
-# Send package name and version to FASTEN and receive a Call Graph for it.
-
 from gitHubAndPyPIParsingUtils import *
+
+'''
+* SPDX-FileCopyrightText: 2022 Michele Scarlato <michele.scarlato@endocode.com>
+*
+* SPDX-License-Identifier: Apache-2.0
+'''
 
 class ReceiveLocallyLicensesInformation:
 
@@ -8,8 +12,6 @@ class ReceiveLocallyLicensesInformation:
     # add the source (e.g. GitHub or PyPI) to the dict!
     def receiveLocallyLicensesInformation(pkgs, LCVurl, i):
         print("Retrieval of license information:")
-
-        #licenses = {0: {'packageName' : '', 'PyPILicense' : '', 'GitHubLicense' : ''}}
         licenses = {}
         for package in pkgs:
             licenses[i] = {}
@@ -22,14 +24,11 @@ class ReceiveLocallyLicensesInformation:
                 licenses[i]['PyPILicense'] = PyPILicense
             if len(PyPILicenseSPDX) > 0:
                 licenses[i]['PyPILicenseSPDX'] = PyPILicenseSPDX
-            #if len(PyPILicense) == 0:
             GitHubURL = retrieveGitHubUrl(jsonResponse, package)
-            print("GitHub URL Retrieved:")
-            print(GitHubURL)
             if len(GitHubURL) > 0:
                 GitHubAPIurl = RetrieveGitHubAPIurl(GitHubURL)
-                if len(GitHubURL) > 0:
-                    print(GitHubURL)
+                if len(GitHubAPIurl) > 0:
+                    print(GitHubAPIurl)
                     GitHubLicense, GitHubLicenseSPDX = RetrieveLicenseFromGitHub(GitHubAPIurl, LCVurl)
                     if GitHubLicense != "":
                         if GitHubLicense is not None:
@@ -37,5 +36,5 @@ class ReceiveLocallyLicensesInformation:
                     if GitHubLicenseSPDX != "":
                         if GitHubLicenseSPDX is not None:
                             licenses[i]['GitHubLicenseSPDX'] = GitHubLicenseSPDX
-            i+=1
+            i += 1
         return licenses


### PR DESCRIPTION
@lisa-noeth 
I created this PR, that does not necessarily need to be merged (at least not since the other branches are merged/fixed).

I add a schema of the main logic below.

Main assumption:
- Developer(s) declares the outbound license as a parameter, using the `--spdx_license ` flag.

The pypi-plugin produces three reports if license violations occur.
The reports have simply printed on the screen when the pypi-plugin is executed.

The three reports are:

1.  report generation for license violations at the package level:
the set of inbound licenses is composed of all the licenses retrieved at the package level (from FASTEN and locally, if FASTEN doesn't have a specific package), including all the dependency trees (resolved with the pypi-resolver component).
The set of inbound licenses is compared with the outbound declared by the developer(s). 

2.  report generation for license violations at the file level (license information retrieved from FASTEN):
each license(s) detected for a file is applied to its callables, and it is compared with the outbound declared by the developer(s). 
Single callables with license violations are reported.

3. report generation regarding file with license(s) not compatible with the license detected for the belonging package:
Scancode may detect licenses at the file level that are not compatible with the one declared on PyPI or on GitHub by the developer(s). These cases are object of this report.

Important to mention that, currently the pypi-plugin is not considering to run Scancode locally for the license detection at the file level, so reports 2 and 3 rely on information retrieved from the FASTEN server.


![Pypi-licensing_logic drawio](https://user-images.githubusercontent.com/10910590/178026062-da620aed-33ed-4c19-b56b-1b29ec6ef3a2.png)
[[link to draw.io](https://drive.google.com/file/d/1IVhRC_L1H-yExiMyeWh095cEHou6ttdU/view?usp=sharing)]